### PR TITLE
feat: add delegate endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,4 +1,4 @@
-import { fetchData, insertParams, stringifyQuery } from './utils'
+import { deleteData, fetchData, insertParams, stringifyQuery } from './utils'
 import { paths } from './types/api'
 
 type Primitive = string | number | boolean | null
@@ -25,4 +25,22 @@ export function callEndpoint<T extends keyof paths>(
   const url = `${baseUrl}${pathname}${search}`
 
   return fetchData(url, params?.body)
+}
+
+export function deleteEndpoint<T extends keyof paths>(
+  baseUrl: string,
+  path: T,
+  parameters?: paths[T]['get']['parameters'],
+  rawUrl?: string,
+): Promise<paths[T]['get']['responses'][200]['schema']> {
+  if (rawUrl) {
+    return fetchData(rawUrl)
+  }
+
+  const params = parameters as Params
+  const pathname = insertParams(path, params?.path)
+  const search = stringifyQuery(params?.query)
+  const url = `${baseUrl}${pathname}${search}`
+
+  return deleteData(url, params?.body)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,20 @@
 import { callEndpoint } from './endpoint'
 import { operations } from './types/api'
-import { SafeTransactionEstimation, TransactionDetails, TransactionListPage } from './types/transactions'
+import { Page, SafeTransactionEstimation, TransactionDetails, TransactionListPage } from './types/transactions'
 import { FiatCurrencies, OwnedSafes, SafeBalanceResponse, SafeCollectibleResponse, SafeInfo } from './types/common'
 import { ChainListResponse, ChainInfo } from './types/chains'
 import { SafeAppsResponse } from './types/safe-apps'
 import { MasterCopyReponse } from './types/master-copies'
 import { DecodedDataResponse } from './types/decoded-data'
 import { DEFAULT_BASE_URL } from './config'
+import {
+  AddDelegateRequest,
+  Delegate,
+  DelegateResponse,
+  DelegatesRequest,
+  DeleteDelegateRequest,
+  DeleteSafeDelegateRequest,
+} from './types/delegates'
 export * from './types/safe-apps'
 export * from './types/transactions'
 export * from './types/chains'
@@ -155,7 +163,7 @@ export function getChainsConfig(query?: operations['chains_list']['parameters'][
  */
 export function getChainConfig(chainId: string): Promise<ChainInfo> {
   return callEndpoint(baseUrl, '/v1/chains/{chainId}', {
-    path: { chainId: chainId },
+    path: { chainId },
   })
 }
 
@@ -167,7 +175,7 @@ export function getSafeApps(
   query: operations['safe_apps_read']['parameters']['query'] = {},
 ): Promise<SafeAppsResponse> {
   return callEndpoint(baseUrl, '/v1/chains/{chainId}/safe-apps', {
-    path: { chainId: chainId },
+    path: { chainId },
     query,
   })
 }
@@ -177,7 +185,7 @@ export function getSafeApps(
  */
 export function getMasterCopies(chainId: string): Promise<MasterCopyReponse> {
   return callEndpoint(baseUrl, '/v1/chains/{chainId}/about/master-copies', {
-    path: { chainId: chainId },
+    path: { chainId },
   })
 }
 
@@ -189,8 +197,61 @@ export function getDecodedData(
   encodedData: operations['data_decoder']['parameters']['body']['data'],
 ): Promise<DecodedDataResponse> {
   return callEndpoint(baseUrl, '/v1/chains/{chainId}/data-decoder', {
-    path: { chainId: chainId },
+    path: { chainId },
     body: { data: encodedData },
+  })
+}
+
+/**
+ * Returns a list of delegates
+ */
+export function getDelegates(chainId: string, query: DelegatesRequest = {}): Promise<DelegateResponse> {
+  // TODO: Fix union return type
+  //@ts-ignore
+  return callEndpoint(baseUrl, '/v1/chains/{chainId}/delegates', {
+    path: { chainId },
+    query,
+  })
+}
+
+/**
+ * Adds a new delegate
+ */
+export function addDelegate(chainId: string, body: AddDelegateRequest): Promise<void> {
+  // TODO: Fix union return type
+  //@ts-ignore
+  return callEndpoint(baseUrl, '/v1/chains/{chainId}/delegates', {
+    path: { chainId },
+    body,
+  })
+}
+
+/**
+ * Deletes a delegate
+ */
+export function deleteDelegate(
+  chainId: string,
+  delegateAddress: string,
+  body: DeleteDelegateRequest,
+): Promise<unknown> {
+  return callEndpoint(baseUrl, '/v1/chains/{chainId}/delegates/{delegateAddress}', {
+    path: { chainId, delegateAddress },
+    body,
+  })
+}
+
+/**
+ * Deletes a Safe delegate
+ */
+export function deleteSafeDelegate(
+  chainId: string,
+  address: string,
+  delegateAddress: string,
+  body: DeleteSafeDelegateRequest,
+): Promise<unknown> {
+  return callEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{address}/delegates/{delegateAddress}', {
+    path: { chainId, address, delegateAddress },
+    body,
   })
 }
 /* eslint-enable @typescript-eslint/explicit-module-boundary-types */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { callEndpoint } from './endpoint'
+import { callEndpoint, deleteEndpoint } from './endpoint'
 import { operations } from './types/api'
 import { Page, SafeTransactionEstimation, TransactionDetails, TransactionListPage } from './types/transactions'
 import { FiatCurrencies, OwnedSafes, SafeBalanceResponse, SafeCollectibleResponse, SafeInfo } from './types/common'
@@ -234,7 +234,7 @@ export function deleteDelegate(
   delegateAddress: string,
   body: DeleteDelegateRequest,
 ): Promise<unknown> {
-  return callEndpoint(baseUrl, '/v1/chains/{chainId}/delegates/{delegateAddress}', {
+  return deleteEndpoint(baseUrl, '/v1/chains/{chainId}/delegates/{delegateAddress}', {
     path: { chainId, delegateAddress },
     body,
   })
@@ -249,7 +249,7 @@ export function deleteSafeDelegate(
   delegateAddress: string,
   body: DeleteSafeDelegateRequest,
 ): Promise<unknown> {
-  return callEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{address}/delegates/{delegateAddress}', {
+  return deleteEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{address}/delegates/{delegateAddress}', {
     path: { chainId, address, delegateAddress },
     body,
   })

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -5,11 +5,20 @@ import {
   SafeTransactionEstimation,
   SafeTransactionEstimationRequest,
   TransactionListPage,
+  Page,
 } from './transactions'
 import { ChainListResponse, ChainInfo } from './chains'
 import { SafeAppsResponse } from './safe-apps'
 import { DecodedDataRequest, DecodedDataResponse } from './decoded-data'
 import { MasterCopyReponse } from './master-copies'
+import {
+  AddDelegateRequest,
+  Delegate,
+  DelegateResponse,
+  DelegatesRequest,
+  DeleteDelegateRequest,
+  DeleteSafeDelegateRequest,
+} from './delegates'
 
 export interface paths {
   '/v1/chains/{chainId}/safes/{address}': {
@@ -142,6 +151,46 @@ export interface paths {
       path: {
         chainId: string
       }
+    }
+  }
+  '/v1/chains/{chainId}/delegates':
+    | {
+        get: operations['get_delegates']
+        parameters: {
+          path: {
+            chainId: string
+          }
+          query: DelegatesRequest
+        }
+      }
+    | {
+        get: operations['add_delegate']
+        parameters: {
+          path: {
+            chainId: string
+          }
+          body: AddDelegateRequest
+        }
+      }
+  '/v1/chains/{chainId}/delegates/{delegateAddress}': {
+    get: operations['delete_delegate']
+    parameters: {
+      path: {
+        chainId: string
+        delegateAddress: string
+      }
+      body: DeleteDelegateRequest
+    }
+  }
+  '/v1/chains/{chainId}/safes/{address}/delegates/{delegateAddress}': {
+    get: operations['delete_safe_delegate']
+    parameters: {
+      path: {
+        chainId: string
+        address: string
+        delegateAddress: string
+      }
+      body: DeleteSafeDelegateRequest
     }
   }
 }
@@ -391,6 +440,63 @@ export interface operations {
     responses: {
       200: {
         schema: DecodedDataResponse
+      }
+    }
+  }
+  get_delegates: {
+    parameters: {
+      path: {
+        chainId: string
+      }
+      query: DelegatesRequest
+    }
+    responses: {
+      200: {
+        schema: DelegateResponse
+      }
+    }
+  }
+  add_delegate: {
+    parameters: {
+      path: {
+        chainId: string
+      }
+      body: DelegatesRequest
+    }
+    responses: {
+      200: {
+        schema: void
+      }
+    }
+  }
+  delete_delegate: {
+    parameters: {
+      path: {
+        chainId: string
+        delegateAddress: string
+      }
+      body: DeleteDelegateRequest
+    }
+    responses: {
+      200: {
+        // TODO: Determine return type
+        schema: unknown
+      }
+    }
+  }
+  delete_safe_delegate: {
+    parameters: {
+      path: {
+        chainId: string
+        address: string
+        delegateAddress: string
+      }
+      body: DeleteSafeDelegateRequest
+    }
+    responses: {
+      200: {
+        // TODO: Determine return type
+        schema: unknown
       }
     }
   }

--- a/src/types/chains.ts
+++ b/src/types/chains.ts
@@ -1,3 +1,5 @@
+import { Page } from './transactions'
+
 export enum RPC_AUTHENTICATION {
   API_KEY_PATH = 'API_KEY_PATH',
   NO_AUTHENTICATION = 'NO_AUTHENTICATION',
@@ -82,8 +84,4 @@ export type ChainInfo = {
   features: FEATURES[]
 }
 
-export type ChainListResponse = {
-  next: string | null
-  previous: string | null
-  results: ChainInfo[]
-}
+export type ChainListResponse = Page<ChainInfo>

--- a/src/types/chains.ts
+++ b/src/types/chains.ts
@@ -64,7 +64,7 @@ export enum FEATURES {
 }
 
 // Remain agnostic as possible and reference what is returned in the CGW, i.e.
-// https://gnosis.github.io/safe-client-gateway/docs/routes/chains/models/struct.ChainInfo.html
+// https://safe.global/safe-client-gateway/docs/routes/chains/models/struct.ChainInfo.html
 export type ChainInfo = {
   transactionService: string
   chainId: string // Restricted by what is returned by the CGW

--- a/src/types/delegates.ts
+++ b/src/types/delegates.ts
@@ -1,0 +1,37 @@
+import { Page } from './transactions'
+
+export type Delegate = {
+  safe?: string
+  delegate: string
+  delegator: string
+  label: string
+}
+
+export type DelegateResponse = Page<Delegate>
+
+export type DelegatesRequest = {
+  safe?: string
+  delegate?: string
+  delegator?: string
+  label?: string
+}
+
+export type AddDelegateRequest = {
+  safe?: string
+  delegate: string
+  delegator: string
+  signature: string
+  label: string
+}
+
+export type DeleteDelegateRequest = {
+  delegate: string
+  delegator: string
+  signature: string
+}
+
+export type DeleteSafeDelegateRequest = {
+  safe: string
+  delegate: string
+  signature: string
+}

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -253,7 +253,7 @@ export type ConflictHeader = {
 
 export type TransactionListItem = Transaction | Label | ConflictHeader
 
-type Page<T> = {
+export type Page<T> = {
   next?: string
   previous?: string
   results: Array<T>

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -234,7 +234,7 @@ export type DateLabel = {
 }
 
 /**
- * @see https://gnosis.github.io/safe-client-gateway/docs/routes/transactions/models/summary/enum.Label.html
+ * @see https://safe.global/safe-client-gateway/docs/routes/transactions/models/summary/enum.Label.html
  */
 export enum LabelValue {
   Queued = 'Queued',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,3 +66,36 @@ export async function fetchData<T>(url: string, body?: unknown): Promise<T> {
 
   return json
 }
+
+export async function deleteData<T>(url: string, body?: unknown): Promise<T> {
+  let options:
+    | {
+        method: 'DELETE'
+        headers: Record<string, string>
+        body: string
+      }
+    | undefined
+  if (body != null) {
+    options = {
+      method: 'DELETE',
+      body: typeof body === 'string' ? body : JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' },
+    }
+  }
+
+  const resp = await fetch(url, options)
+  const json = await resp.json()
+
+  if (!resp.ok) {
+    let errTxt = ''
+    try {
+      const err = json as ErrorResponse
+      errTxt = `${err.code}: ${err.message}`
+    } catch (e) {
+      errTxt = resp.statusText
+    }
+    throw new Error(errTxt)
+  }
+
+  return json
+}


### PR DESCRIPTION
## Overview

This adds the add, edit, delete and delete (all?) endpoints to the SDK as well as their types. There are still a few TODOs:

- It seems as though the `DELETE` method is not allowed by the CORS policy. As such, the delete functions aren't working and I can't confirm the return types (although the typed ones are taken from [the docs](https://safe-global.github.io/safe-client-gateway/docs/routes/delegates/index.html)).
- The get/add functions have a union return type for the `'/v1/chains/{chainId}/delegates'` endpoint that needs to be fixed.