### PR TITLE
Chore: use CommonJS modules for dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "./dist/",
-    "module": "esnext",
+    "module": "commonjs",
     "target": "es6",
     "lib": ["es2019", "dom"],
     "sourceMap": true,


### PR DESCRIPTION
#96 didn't work with web-core, it wants CommonJS modules.

I've tested it by copying the dist folder to web-core's node_modules.