### PR TITLE
fix: add `trusted` to `MultisigExecutionDetails`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "3.4.5",
+  "version": "3.4.6",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -370,6 +370,7 @@ export type MultisigExecutionDetails = {
   confirmations: MultisigConfirmation[]
   rejectors?: AddressEx[]
   gasTokenInfo?: TokenInfo
+  trusted: boolean
 }
 
 export type DetailedExecutionInfo = ModuleExecutionDetails | MultisigExecutionDetails


### PR DESCRIPTION
## What it solves

Corrects the types for [the forthcoming `trusted` flag](https://github.com/safe-global/safe-client-gateway/issues/1005).

## How this PR fixes it

The `boolean` `MultisigExecutionDetails['trusted']` flag has been added.