### PR TITLE
feat: EIP-1271 propose, confirm and list endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -295,7 +295,7 @@ export function getDecodedData(
 }
 
 /**
- * Returns a list of `SafeMessage`s
+ * Returns list of `SafeMessage`s
  */
 export function getSafeMessages(chainId: string, address: string, pageUrl?: string): Promise<SafeMessageListPage> {
   return callEndpoint(

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export * from './types/chains'
 export * from './types/common'
 export * from './types/master-copies'
 export * from './types/decoded-data'
+export * from './types/safe-messages'
 
 // Can be set externally to a different CGW host
 let baseUrl: string = DEFAULT_BASE_URL

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import type { ChainListResponse, ChainInfo } from './types/chains'
 import type { SafeAppsResponse } from './types/safe-apps'
 import type { MasterCopyReponse } from './types/master-copies'
 import type { DecodedDataResponse } from './types/decoded-data'
+import type { SafeMessageListPage } from './types/safe-messages'
 import { DEFAULT_BASE_URL } from './config'
 
 export * from './types/safe-info'
@@ -291,4 +292,45 @@ export function getDecodedData(
     body: { data: encodedData },
   })
 }
+
+/**
+ * Returns a list of `SafeMessage`s
+ */
+export function getSafeMessages(chainId: string, address: string, pageUrl?: string): Promise<SafeMessageListPage> {
+  return callEndpoint(
+    baseUrl,
+    '/v1/chains/{chainId}/safes/{safe_address}/messages',
+    { path: { chainId, safe_address: address }, query: {} },
+    pageUrl,
+  )
+}
+
+/**
+ * Propose a new `SafeMessage` for other owners to sign
+ */
+export function proposeSafeMessage(
+  chainId: string,
+  address: string,
+  body: operations['propose_safe_message']['parameters']['body'],
+): Promise<void> {
+  return callEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{safe_address}/messages', {
+    path: { chainId, safe_address: address },
+    body,
+  })
+}
+
+/**
+ * Add a confirmation to a `SafeMessage`
+ */
+export function confirmSafeMessage(
+  chainId: string,
+  messageHash: string,
+  body: operations['confirm_safe_message']['parameters']['body'],
+): Promise<void> {
+  return callEndpoint(baseUrl, '/v1/chains/{chainId}/messages/{message_hash}/signatures', {
+    path: { chainId, message_hash: messageHash },
+    body,
+  })
+}
+
 /* eslint-enable @typescript-eslint/explicit-module-boundary-types */

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -20,6 +20,7 @@ import type { ChainListResponse, ChainInfo } from './chains'
 import type { SafeAppsResponse } from './safe-apps'
 import type { DecodedDataRequest, DecodedDataResponse } from './decoded-data'
 import type { MasterCopyReponse } from './master-copies'
+import type { ConfirmSafeMessageRequest, ProposeSafeMessageRequest } from './safe-messages'
 
 export interface paths {
   '/v1/chains/{chainId}/safes/{address}': {
@@ -191,6 +192,28 @@ export interface paths {
     parameters: {
       path: {
         chainId: string
+      }
+    }
+  }
+  '/v1/chains/{chainId}/safes/{safe_address}/messages': {
+    get:
+      | operations['get_safe_messages']
+      /** This is actually supposed to be POST but it breaks our type paradise */
+      | operations['propose_safe_message']
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+      }
+    }
+  }
+  '/v1/chains/{chainId}/messages/{message_hash}/signatures': {
+    /** This is actually supposed to be POST but it breaks our type paradise */
+    get: operations['confirm_safe_message']
+    parameters: {
+      path: {
+        chainId: string
+        message_hash: string
       }
     }
   }
@@ -539,6 +562,51 @@ export interface operations {
     responses: {
       200: {
         schema: DecodedDataResponse
+      }
+    }
+  }
+  get_safe_messages: {
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+      }
+      query: {
+        /** Taken from the Page['next'] or Page['previous'] */
+        page_url?: string
+      }
+    }
+    responses: {
+      200: {
+        schema: SignedMessageListPage
+      }
+    }
+  }
+  propose_safe_message: {
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+      }
+      body: ProposeSafeMessageRequest
+    }
+    responses: {
+      200: {
+        schema: void
+      }
+    }
+  }
+  confirm_safe_message: {
+    parameters: {
+      path: {
+        chainId: string
+        message_hash: string
+      }
+      body: ConfirmSafeMessageRequest
+    }
+    responses: {
+      200: {
+        schema: void
       }
     }
   }

--- a/src/types/safe-messages.ts
+++ b/src/types/safe-messages.ts
@@ -1,0 +1,49 @@
+import type { AddressEx, Page } from './common'
+
+export enum SafeMessageListItemType {
+  DATE_LABEL = 'DATE_LABEL',
+  MESSAGE = 'MESSAGE',
+}
+
+export type SafeMessageDateLabel = {
+  type: SafeMessageListItemType.DATE_LABEL
+  timestamp: number
+}
+
+export enum SafeMessageStatus {
+  NEEDS_CONFIRMATION = 'NEEDS_CONFIRMATION',
+  CONFIRMED = 'CONFIRMED',
+}
+
+export type SafeMessage = {
+  type: SafeMessageListItemType.MESSAGE
+  messageHash: string
+  status: SafeMessageStatus
+  logoUri?: string
+  name?: string
+  message: string | Record<string, any>
+  creationTimestamp: number
+  modifiedTimestamp: number
+  confirmationsSubmitted: number
+  confirmationsRequired: number
+  proposedBy: AddressEx
+  confirmations: {
+    owner: AddressEx
+    signature: string
+  }[]
+  preparedSignature?: string
+}
+
+export type SafeMessageListItem = SafeMessageDateLabel | SafeMessage
+
+export type SafeMessageListPage = Page<SafeMessageListItem>
+
+export type ProposeSafeMessageRequest = {
+  message: string | Record<string, any>
+  safeAppId: number
+  signature: string
+}
+
+export type ConfirmSafeMessageRequest = {
+  signature: string
+}

--- a/src/types/safe-messages.ts
+++ b/src/types/safe-messages.ts
@@ -15,13 +15,36 @@ export enum SafeMessageStatus {
   CONFIRMED = 'CONFIRMED',
 }
 
+interface TypedDataDomain {
+  name?: string
+  version?: string
+  chainId?: any // BigNumberish
+  verifyingContract?: string
+  salt?: ArrayLike<number> | string // BytesLike
+}
+
+interface TypedDataTypes {
+  name: string
+  type: string
+}
+
+type TypedMessageTypes = {
+  [key: string]: TypedDataTypes[]
+}
+
+export type EIP712TypedData = {
+  domain: TypedDataDomain
+  types: TypedMessageTypes
+  message: Record<string, any>
+}
+
 export type SafeMessage = {
   type: SafeMessageListItemType.MESSAGE
   messageHash: string
   status: SafeMessageStatus
   logoUri: string | null
   name: string | null
-  message: string | Record<string, any>
+  message: string | EIP712TypedData
   creationTimestamp: number
   modifiedTimestamp: number
   confirmationsSubmitted: number

--- a/src/types/safe-messages.ts
+++ b/src/types/safe-messages.ts
@@ -19,8 +19,8 @@ export type SafeMessage = {
   type: SafeMessageListItemType.MESSAGE
   messageHash: string
   status: SafeMessageStatus
-  logoUri?: string
-  name?: string
+  logoUri: string | null
+  name: string | null
   message: string | Record<string, any>
   creationTimestamp: number
   modifiedTimestamp: number

--- a/src/types/safe-messages.ts
+++ b/src/types/safe-messages.ts
@@ -18,7 +18,7 @@ export enum SafeMessageStatus {
 interface TypedDataDomain {
   name?: string
   version?: string
-  chainId?: any // BigNumberish
+  chainId?: unknown // BigNumberish
   verifyingContract?: string
   salt?: ArrayLike<number> | string // BytesLike
 }
@@ -35,7 +35,7 @@ type TypedMessageTypes = {
 export type EIP712TypedData = {
   domain: TypedDataDomain
   types: TypedMessageTypes
-  message: Record<string, any>
+  message: Record<string, unknown>
 }
 
 export type SafeMessage = {
@@ -62,7 +62,7 @@ export type SafeMessageListItem = SafeMessageDateLabel | SafeMessage
 export type SafeMessageListPage = Page<SafeMessageListItem>
 
 export type ProposeSafeMessageRequest = {
-  message: string | Record<string, any>
+  message: SafeMessage['message']
   safeAppId: number
   signature: string
 }


### PR DESCRIPTION
## What it solves

This integrates the endpoints to get all, propose or confirm `SafeMessage`s.

## How this PR fixes it

The endpoints and types are implemented according to the [backend spec](https://www.notion.so/EIP-1271-backend-specifications-c0c6ef187425475288216021a7521c82?d=3345071f763246439acfe3c765645369#ad5426ada7c54158b8b04b9a4ca25bac).