### PR TITLE
Refactor: allow both get and post methods on the same endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "3.4.7",
+  "version": "3.5.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,15 +1,23 @@
 import { fetchData, insertParams, stringifyQuery } from './utils'
-import type { GetEndpoint, paths, PostEndpoint } from './types/api'
+import type { GetEndpoint, paths, PostEndpoint, Primitive } from './types/api'
+
+function makeUrl(
+  baseUrl: string,
+  path: string,
+  pathParams?: Record<string, Primitive>,
+  query?: Record<string, Primitive>,
+): string {
+  const pathname = insertParams(path, pathParams)
+  const search = stringifyQuery(query)
+  return `${baseUrl}${pathname}${search}`
+}
 
 export function postEndpoint<T extends keyof paths>(
   baseUrl: string,
   path: T,
   params?: paths[T] extends PostEndpoint ? paths[T]['post']['parameters'] : never,
 ): Promise<paths[T] extends PostEndpoint ? paths[T]['post']['responses'][200]['schema'] : never> {
-  const pathname = insertParams(path as string, params?.path)
-  const search = stringifyQuery(params?.query)
-  const url = `${baseUrl}${pathname}${search}`
-
+  const url = makeUrl(baseUrl, path as string, params?.path, params?.query)
   return fetchData(url, params?.body)
 }
 
@@ -22,10 +30,6 @@ export function getEndpoint<T extends keyof paths>(
   if (rawUrl) {
     return fetchData(rawUrl)
   }
-
-  const pathname = insertParams(path as string, params?.path)
-  const search = stringifyQuery(params?.query)
-  const url = `${baseUrl}${pathname}${search}`
-
+  const url = makeUrl(baseUrl, path as string, params?.path, params?.query)
   return fetchData(url)
 }

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,28 +1,31 @@
 import { fetchData, insertParams, stringifyQuery } from './utils'
-import type { paths } from './types/api'
+import type { GetEndpoint, paths, PostEndpoint } from './types/api'
 
-type Primitive = string | number | boolean | null
-
-interface Params {
-  path?: { [key: string]: Primitive }
-  query?: { [key: string]: Primitive }
-  body?: unknown
-}
-
-export function callEndpoint<T extends keyof paths>(
+export function postEndpoint<T extends keyof paths>(
   baseUrl: string,
   path: T,
-  parameters?: paths[T]['get']['parameters'],
-  rawUrl?: string,
-): Promise<paths[T]['get']['responses'][200]['schema']> {
-  if (rawUrl) {
-    return fetchData(rawUrl)
-  }
-
-  const params = parameters as Params
-  const pathname = insertParams(path, params?.path)
+  params?: paths[T] extends PostEndpoint ? paths[T]['post']['parameters'] : never,
+): Promise<paths[T] extends PostEndpoint ? paths[T]['post']['responses'][200]['schema'] : never> {
+  const pathname = insertParams(path as string, params?.path)
   const search = stringifyQuery(params?.query)
   const url = `${baseUrl}${pathname}${search}`
 
   return fetchData(url, params?.body)
+}
+
+export function getEndpoint<T extends keyof paths>(
+  baseUrl: string,
+  path: T,
+  params?: paths[T] extends GetEndpoint ? paths[T]['get']['parameters'] : never,
+  rawUrl?: string,
+): Promise<paths[T] extends GetEndpoint ? paths[T]['get']['responses'][200]['schema'] : never> {
+  if (rawUrl) {
+    return fetchData(rawUrl)
+  }
+
+  const pathname = insertParams(path as string, params?.path)
+  const search = stringifyQuery(params?.query)
+  const url = `${baseUrl}${pathname}${search}`
+
+  return fetchData(url)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { callEndpoint } from './endpoint'
+import { getEndpoint, postEndpoint } from './endpoint'
 import type { operations } from './types/api'
 import type {
   SafeTransactionEstimation,
@@ -48,7 +48,7 @@ export const setBaseUrl = (url: string): void => {
  * Get basic information about a Safe. E.g. owners, modules, version etc
  */
 export function getSafeInfo(chainId: string, address: string): Promise<SafeInfo> {
-  return callEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{address}', { path: { chainId, address } })
+  return getEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{address}', { path: { chainId, address } })
 }
 
 /**
@@ -60,7 +60,7 @@ export function getIncomingTransfers(
   query?: operations['incoming_transfers']['parameters']['query'],
   pageUrl?: string,
 ): Promise<SafeIncomingTransfersResponse> {
-  return callEndpoint(
+  return getEndpoint(
     baseUrl,
     '/v1/chains/{chainId}/safes/{address}/incoming-transfers/',
     {
@@ -80,7 +80,7 @@ export function getModuleTransactions(
   query?: operations['module_transactions']['parameters']['query'],
   pageUrl?: string,
 ): Promise<SafeModuleTransactionsResponse> {
-  return callEndpoint(
+  return getEndpoint(
     baseUrl,
     '/v1/chains/{chainId}/safes/{address}/module-transactions/',
     {
@@ -100,7 +100,7 @@ export function getMultisigTransactions(
   query?: operations['multisig_transactions']['parameters']['query'],
   pageUrl?: string,
 ): Promise<SafeMultisigTransactionsResponse> {
-  return callEndpoint(
+  return getEndpoint(
     baseUrl,
     '/v1/chains/{chainId}/safes/{address}/multisig-transactions/',
     {
@@ -120,7 +120,7 @@ export function getBalances(
   currency = 'usd',
   query: operations['safes_balances_list']['parameters']['query'] = {},
 ): Promise<SafeBalanceResponse> {
-  return callEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{address}/balances/{currency}', {
+  return getEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{address}/balances/{currency}', {
     path: { chainId, address, currency },
     query,
   })
@@ -130,14 +130,14 @@ export function getBalances(
  * Get a list of supported fiat currencies (e.g. USD, EUR etc)
  */
 export function getFiatCurrencies(): Promise<FiatCurrencies> {
-  return callEndpoint(baseUrl, '/v1/balances/supported-fiat-codes')
+  return getEndpoint(baseUrl, '/v1/balances/supported-fiat-codes')
 }
 
 /**
  * Get the addresses of all Safes belonging to an owner
  */
 export function getOwnedSafes(chainId: string, address: string): Promise<OwnedSafes> {
-  return callEndpoint(baseUrl, '/v1/chains/{chainId}/owners/{address}/safes', { path: { chainId, address } })
+  return getEndpoint(baseUrl, '/v1/chains/{chainId}/owners/{address}/safes', { path: { chainId, address } })
 }
 
 /**
@@ -148,7 +148,7 @@ export function getCollectibles(
   address: string,
   query: operations['safes_collectibles_list']['parameters']['query'] = {},
 ): Promise<SafeCollectibleResponse[]> {
-  return callEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{address}/collectibles', {
+  return getEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{address}/collectibles', {
     path: { chainId, address },
     query,
   })
@@ -163,7 +163,7 @@ export function getCollectiblesPage(
   query: operations['safes_collectibles_list_paginated']['parameters']['query'] = {},
   pageUrl?: string,
 ): Promise<SafeCollectiblesPage> {
-  return callEndpoint(
+  return getEndpoint(
     baseUrl,
     '/v2/chains/{chainId}/safes/{address}/collectibles',
     { path: { chainId, address }, query },
@@ -179,7 +179,7 @@ export function getTransactionHistory(
   address: string,
   pageUrl?: string,
 ): Promise<TransactionListPage> {
-  return callEndpoint(
+  return getEndpoint(
     baseUrl,
     '/v1/chains/{chainId}/safes/{safe_address}/transactions/history',
     { path: { chainId, safe_address: address }, query: {} },
@@ -196,7 +196,7 @@ export function getTransactionQueue(
   pageUrl?: string,
   trusted?: boolean,
 ): Promise<TransactionListPage> {
-  return callEndpoint(
+  return getEndpoint(
     baseUrl,
     '/v1/chains/{chainId}/safes/{safe_address}/transactions/queued',
     { path: { chainId, safe_address: address }, query: { trusted } },
@@ -208,7 +208,7 @@ export function getTransactionQueue(
  * Get the details of an individual transaction by its id
  */
 export function getTransactionDetails(chainId: string, transactionId: string): Promise<TransactionDetails> {
-  return callEndpoint(baseUrl, '/v1/chains/{chainId}/transactions/{transactionId}', {
+  return getEndpoint(baseUrl, '/v1/chains/{chainId}/transactions/{transactionId}', {
     path: { chainId, transactionId },
   })
 }
@@ -221,7 +221,7 @@ export function postSafeGasEstimation(
   address: string,
   body: operations['post_safe_gas_estimation']['parameters']['body'],
 ): Promise<SafeTransactionEstimation> {
-  return callEndpoint(baseUrl, '/v2/chains/{chainId}/safes/{safe_address}/multisig-transactions/estimations', {
+  return postEndpoint(baseUrl, '/v2/chains/{chainId}/safes/{safe_address}/multisig-transactions/estimations', {
     path: { chainId, safe_address: address },
     body,
   })
@@ -235,7 +235,7 @@ export function proposeTransaction(
   address: string,
   body: operations['propose_transaction']['parameters']['body'],
 ): Promise<TransactionDetails> {
-  return callEndpoint(baseUrl, '/v1/chains/{chainId}/transactions/{safe_address}/propose', {
+  return postEndpoint(baseUrl, '/v1/chains/{chainId}/transactions/{safe_address}/propose', {
     path: { chainId, safe_address: address },
     body,
   })
@@ -245,7 +245,7 @@ export function proposeTransaction(
  * Returns all defined chain configs
  */
 export function getChainsConfig(query?: operations['chains_list']['parameters']['query']): Promise<ChainListResponse> {
-  return callEndpoint(baseUrl, '/v1/chains', {
+  return getEndpoint(baseUrl, '/v1/chains', {
     query,
   })
 }
@@ -254,7 +254,7 @@ export function getChainsConfig(query?: operations['chains_list']['parameters'][
  * Returns a chain config
  */
 export function getChainConfig(chainId: string): Promise<ChainInfo> {
-  return callEndpoint(baseUrl, '/v1/chains/{chainId}', {
+  return getEndpoint(baseUrl, '/v1/chains/{chainId}', {
     path: { chainId: chainId },
   })
 }
@@ -266,7 +266,7 @@ export function getSafeApps(
   chainId: string,
   query: operations['safe_apps_read']['parameters']['query'] = {},
 ): Promise<SafeAppsResponse> {
-  return callEndpoint(baseUrl, '/v1/chains/{chainId}/safe-apps', {
+  return getEndpoint(baseUrl, '/v1/chains/{chainId}/safe-apps', {
     path: { chainId: chainId },
     query,
   })
@@ -276,7 +276,7 @@ export function getSafeApps(
  * Returns list of Master Copies
  */
 export function getMasterCopies(chainId: string): Promise<MasterCopyReponse> {
-  return callEndpoint(baseUrl, '/v1/chains/{chainId}/about/master-copies', {
+  return getEndpoint(baseUrl, '/v1/chains/{chainId}/about/master-copies', {
     path: { chainId: chainId },
   })
 }
@@ -288,7 +288,7 @@ export function getDecodedData(
   chainId: string,
   encodedData: operations['data_decoder']['parameters']['body']['data'],
 ): Promise<DecodedDataResponse> {
-  return callEndpoint(baseUrl, '/v1/chains/{chainId}/data-decoder', {
+  return postEndpoint(baseUrl, '/v1/chains/{chainId}/data-decoder', {
     path: { chainId: chainId },
     body: { data: encodedData },
   })
@@ -298,7 +298,7 @@ export function getDecodedData(
  * Returns list of `SafeMessage`s
  */
 export function getSafeMessages(chainId: string, address: string, pageUrl?: string): Promise<SafeMessageListPage> {
-  return callEndpoint(
+  return getEndpoint(
     baseUrl,
     '/v1/chains/{chainId}/safes/{safe_address}/messages',
     { path: { chainId, safe_address: address }, query: {} },
@@ -314,7 +314,7 @@ export function proposeSafeMessage(
   address: string,
   body: operations['propose_safe_message']['parameters']['body'],
 ): Promise<void> {
-  return callEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{safe_address}/messages', {
+  return postEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{safe_address}/messages', {
     path: { chainId, safe_address: address },
     body,
   })
@@ -328,7 +328,7 @@ export function confirmSafeMessage(
   messageHash: string,
   body: operations['confirm_safe_message']['parameters']['body'],
 ): Promise<void> {
-  return callEndpoint(baseUrl, '/v1/chains/{chainId}/messages/{message_hash}/signatures', {
+  return postEndpoint(baseUrl, '/v1/chains/{chainId}/messages/{message_hash}/signatures', {
     path: { chainId, message_hash: messageHash },
     body,
   })

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -20,9 +20,9 @@ import type { ChainListResponse, ChainInfo } from './chains'
 import type { SafeAppsResponse } from './safe-apps'
 import type { DecodedDataRequest, DecodedDataResponse } from './decoded-data'
 import type { MasterCopyReponse } from './master-copies'
-import type { ConfirmSafeMessageRequest, ProposeSafeMessageRequest } from './safe-messages'
+import type { ConfirmSafeMessageRequest, ProposeSafeMessageRequest, SafeMessageListPage } from './safe-messages'
 
-type Primitive = string | number | boolean | null
+export type Primitive = string | number | boolean | null
 
 interface GetParams {
   path?: { [key: string]: Primitive }
@@ -165,8 +165,7 @@ export interface paths extends PathRegistry {
     }
   }
   '/v2/chains/{chainId}/safes/{safe_address}/multisig-transactions/estimations': {
-    /** This is actually supposed to be POST but it breaks our type paradise */
-    get: operations['post_safe_gas_estimation']
+    post: operations['post_safe_gas_estimation']
     parameters: {
       path: {
         chainId: string
@@ -175,8 +174,7 @@ export interface paths extends PathRegistry {
     }
   }
   '/v1/chains/{chainId}/transactions/{safe_address}/propose': {
-    /** This is actually supposed to be POST but it breaks our type paradise */
-    get: operations['propose_transaction']
+    post: operations['propose_transaction']
     parameters: {
       path: {
         chainId: string
@@ -609,7 +607,7 @@ export interface operations {
     }
     responses: {
       200: {
-        schema: SignedMessageListPage
+        schema: SafeMessageListPage
       }
     }
   }

--- a/tests/endpoint.test.ts
+++ b/tests/endpoint.test.ts
@@ -13,13 +13,11 @@ jest.mock('../src/utils', () => {
 
 describe('getEndpoint', () => {
   it('should accept just a path', async () => {
-    await expect(
-      getEndpoint('https://test.test', '/v1/balances/supported-fiat-codes'),
-    ).resolves.toEqual({ success: true })
+    await expect(getEndpoint('https://test.test', '/v1/balances/supported-fiat-codes')).resolves.toEqual({
+      success: true,
+    })
 
-    expect(fetchData).toHaveBeenCalledWith(
-      'https://test.test/v1/balances/supported-fiat-codes'
-    )
+    expect(fetchData).toHaveBeenCalledWith('https://test.test/v1/balances/supported-fiat-codes')
   })
 
   it('should accept a path param', async () => {
@@ -29,43 +27,29 @@ describe('getEndpoint', () => {
       }),
     ).resolves.toEqual({ success: true })
 
-    expect(fetchData).toHaveBeenCalledWith(
-      'https://test.test/v1/chains/4/safes/0x123'
-    )
+    expect(fetchData).toHaveBeenCalledWith('https://test.test/v1/chains/4/safes/0x123')
   })
 
   it('should accept several path params', async () => {
     await expect(
-      getEndpoint(
-        'https://test.test',
-        '/v1/chains/{chainId}/safes/{address}/balances/{currency}',
-        {
-          path: { chainId: '4', address: '0x123', currency: 'usd' },
-          query: {},
-        },
-      ),
+      getEndpoint('https://test.test', '/v1/chains/{chainId}/safes/{address}/balances/{currency}', {
+        path: { chainId: '4', address: '0x123', currency: 'usd' },
+        query: {},
+      }),
     ).resolves.toEqual({ success: true })
 
-    expect(fetchData).toHaveBeenCalledWith(
-      'https://test.test/v1/chains/4/safes/0x123/balances/usd'
-    )
+    expect(fetchData).toHaveBeenCalledWith('https://test.test/v1/chains/4/safes/0x123/balances/usd')
   })
 
   it('should accept query params', async () => {
     await expect(
-      getEndpoint(
-        'https://test.test',
-        '/v1/chains/{chainId}/safes/{address}/balances/{currency}',
-        {
-          path: { chainId: '4', address: '0x123', currency: 'usd' },
-          query: { exclude_spam: true },
-        },
-      ),
+      getEndpoint('https://test.test', '/v1/chains/{chainId}/safes/{address}/balances/{currency}', {
+        path: { chainId: '4', address: '0x123', currency: 'usd' },
+        query: { exclude_spam: true },
+      }),
     ).resolves.toEqual({ success: true })
 
-    expect(fetchData).toHaveBeenCalledWith(
-      'https://test.test/v1/chains/4/safes/0x123/balances/usd?exclude_spam=true'
-    )
+    expect(fetchData).toHaveBeenCalledWith('https://test.test/v1/chains/4/safes/0x123/balances/usd?exclude_spam=true')
   })
 
   it('should accept body', async () => {
@@ -87,20 +71,13 @@ describe('getEndpoint', () => {
     }
 
     await expect(
-      postEndpoint(
-        'https://test.test',
-        '/v1/chains/{chainId}/transactions/{safe_address}/propose',
-        {
-          path: { chainId: '4', safe_address: '0x123' },
-          body,
-        },
-      ),
+      postEndpoint('https://test.test', '/v1/chains/{chainId}/transactions/{safe_address}/propose', {
+        path: { chainId: '4', safe_address: '0x123' },
+        body,
+      }),
     ).resolves.toEqual({ success: true })
 
-    expect(fetchData).toHaveBeenCalledWith(
-      'https://test.test/v1/chains/4/transactions/0x123/propose',
-      body,
-    )
+    expect(fetchData).toHaveBeenCalledWith('https://test.test/v1/chains/4/transactions/0x123/propose', body)
   })
 
   it('should accept a raw URL', async () => {
@@ -124,9 +101,6 @@ describe('getEndpoint', () => {
       }),
     ).resolves.toEqual({ success: true })
 
-    expect(fetchData).toHaveBeenCalledWith(
-      'https://test.test/v1/chains/4/data-decoder',
-      { data: '0x123' },
-    )
+    expect(fetchData).toHaveBeenCalledWith('https://test.test/v1/chains/4/data-decoder', { data: '0x123' })
   })
 })

--- a/tests/endpoint.test.ts
+++ b/tests/endpoint.test.ts
@@ -14,24 +14,24 @@ jest.mock('../src/utils', () => {
 describe('callEndpoint', () => {
   it('should accept just a path', async () => {
     await expect(
-      callEndpoint('https://safe-client.staging.gnosisdev.com', '/v1/balances/supported-fiat-codes'),
+      callEndpoint('https://test.test', '/v1/balances/supported-fiat-codes'),
     ).resolves.toEqual({ success: true })
 
     expect(fetchData).toHaveBeenCalledWith(
-      'https://safe-client.staging.gnosisdev.com/v1/balances/supported-fiat-codes',
+      'https://test.test/v1/balances/supported-fiat-codes',
       undefined,
     )
   })
 
   it('should accept a path param', async () => {
     await expect(
-      callEndpoint('https://safe-client.staging.gnosisdev.com', '/v1/chains/{chainId}/safes/{address}', {
+      callEndpoint('https://test.test', '/v1/chains/{chainId}/safes/{address}', {
         path: { chainId: '4', address: '0x123' },
       }),
     ).resolves.toEqual({ success: true })
 
     expect(fetchData).toHaveBeenCalledWith(
-      'https://safe-client.staging.gnosisdev.com/v1/chains/4/safes/0x123',
+      'https://test.test/v1/chains/4/safes/0x123',
       undefined,
     )
   })
@@ -39,7 +39,7 @@ describe('callEndpoint', () => {
   it('should accept several path params', async () => {
     await expect(
       callEndpoint(
-        'https://safe-client.staging.gnosisdev.com',
+        'https://test.test',
         '/v1/chains/{chainId}/safes/{address}/balances/{currency}',
         {
           path: { chainId: '4', address: '0x123', currency: 'usd' },
@@ -49,7 +49,7 @@ describe('callEndpoint', () => {
     ).resolves.toEqual({ success: true })
 
     expect(fetchData).toHaveBeenCalledWith(
-      'https://safe-client.staging.gnosisdev.com/v1/chains/4/safes/0x123/balances/usd',
+      'https://test.test/v1/chains/4/safes/0x123/balances/usd',
       undefined,
     )
   })
@@ -57,7 +57,7 @@ describe('callEndpoint', () => {
   it('should accept query params', async () => {
     await expect(
       callEndpoint(
-        'https://safe-client.staging.gnosisdev.com',
+        'https://test.test',
         '/v1/chains/{chainId}/safes/{address}/balances/{currency}',
         {
           path: { chainId: '4', address: '0x123', currency: 'usd' },
@@ -67,7 +67,7 @@ describe('callEndpoint', () => {
     ).resolves.toEqual({ success: true })
 
     expect(fetchData).toHaveBeenCalledWith(
-      'https://safe-client.staging.gnosisdev.com/v1/chains/4/safes/0x123/balances/usd?exclude_spam=true',
+      'https://test.test/v1/chains/4/safes/0x123/balances/usd?exclude_spam=true',
       undefined,
     )
   })
@@ -92,7 +92,7 @@ describe('callEndpoint', () => {
 
     await expect(
       callEndpoint(
-        'https://safe-client.staging.gnosisdev.com',
+        'https://test.test',
         '/v1/chains/{chainId}/transactions/{safe_address}/propose',
         {
           path: { chainId: '4', safe_address: '0x123' },
@@ -102,7 +102,7 @@ describe('callEndpoint', () => {
     ).resolves.toEqual({ success: true })
 
     expect(fetchData).toHaveBeenCalledWith(
-      'https://safe-client.staging.gnosisdev.com/v1/chains/4/transactions/0x123/propose',
+      'https://test.test/v1/chains/4/transactions/0x123/propose',
       body,
     )
   })
@@ -110,7 +110,7 @@ describe('callEndpoint', () => {
   it('should accept a raw URL', async () => {
     await expect(
       callEndpoint(
-        'https://safe-client.staging.gnosisdev.com',
+        'https://test.test',
         '/v1/chains/{chainId}/safes/{address}/balances/{currency}',
         { path: { chainId: '4', address: '0x123', currency: 'usd' }, query: { exclude_spam: true } },
         '/test-url?raw=true',

--- a/tests/endpoint.test.ts
+++ b/tests/endpoint.test.ts
@@ -1,5 +1,5 @@
 import { fetchData } from '../src/utils'
-import { callEndpoint } from '../src/endpoint'
+import { getEndpoint, postEndpoint } from '../src/endpoint'
 
 jest.mock('../src/utils', () => {
   const originalModule = jest.requireActual('../src/utils')
@@ -11,34 +11,32 @@ jest.mock('../src/utils', () => {
   }
 })
 
-describe('callEndpoint', () => {
+describe('getEndpoint', () => {
   it('should accept just a path', async () => {
     await expect(
-      callEndpoint('https://test.test', '/v1/balances/supported-fiat-codes'),
+      getEndpoint('https://test.test', '/v1/balances/supported-fiat-codes'),
     ).resolves.toEqual({ success: true })
 
     expect(fetchData).toHaveBeenCalledWith(
-      'https://test.test/v1/balances/supported-fiat-codes',
-      undefined,
+      'https://test.test/v1/balances/supported-fiat-codes'
     )
   })
 
   it('should accept a path param', async () => {
     await expect(
-      callEndpoint('https://test.test', '/v1/chains/{chainId}/safes/{address}', {
+      getEndpoint('https://test.test', '/v1/chains/{chainId}/safes/{address}', {
         path: { chainId: '4', address: '0x123' },
       }),
     ).resolves.toEqual({ success: true })
 
     expect(fetchData).toHaveBeenCalledWith(
-      'https://test.test/v1/chains/4/safes/0x123',
-      undefined,
+      'https://test.test/v1/chains/4/safes/0x123'
     )
   })
 
   it('should accept several path params', async () => {
     await expect(
-      callEndpoint(
+      getEndpoint(
         'https://test.test',
         '/v1/chains/{chainId}/safes/{address}/balances/{currency}',
         {
@@ -49,14 +47,13 @@ describe('callEndpoint', () => {
     ).resolves.toEqual({ success: true })
 
     expect(fetchData).toHaveBeenCalledWith(
-      'https://test.test/v1/chains/4/safes/0x123/balances/usd',
-      undefined,
+      'https://test.test/v1/chains/4/safes/0x123/balances/usd'
     )
   })
 
   it('should accept query params', async () => {
     await expect(
-      callEndpoint(
+      getEndpoint(
         'https://test.test',
         '/v1/chains/{chainId}/safes/{address}/balances/{currency}',
         {
@@ -67,8 +64,7 @@ describe('callEndpoint', () => {
     ).resolves.toEqual({ success: true })
 
     expect(fetchData).toHaveBeenCalledWith(
-      'https://test.test/v1/chains/4/safes/0x123/balances/usd?exclude_spam=true',
-      undefined,
+      'https://test.test/v1/chains/4/safes/0x123/balances/usd?exclude_spam=true'
     )
   })
 
@@ -91,7 +87,7 @@ describe('callEndpoint', () => {
     }
 
     await expect(
-      callEndpoint(
+      postEndpoint(
         'https://test.test',
         '/v1/chains/{chainId}/transactions/{safe_address}/propose',
         {
@@ -109,7 +105,7 @@ describe('callEndpoint', () => {
 
   it('should accept a raw URL', async () => {
     await expect(
-      callEndpoint(
+      getEndpoint(
         'https://test.test',
         '/v1/chains/{chainId}/safes/{address}/balances/{currency}',
         { path: { chainId: '4', address: '0x123', currency: 'usd' }, query: { exclude_spam: true } },
@@ -118,5 +114,19 @@ describe('callEndpoint', () => {
     ).resolves.toEqual({ success: true })
 
     expect(fetchData).toHaveBeenCalledWith('/test-url?raw=true')
+  })
+
+  it('should call a data decoder POST endpoint', async () => {
+    await expect(
+      postEndpoint('https://test.test', '/v1/chains/{chainId}/data-decoder', {
+        path: { chainId: '4' },
+        body: { data: '0x123' },
+      }),
+    ).resolves.toEqual({ success: true })
+
+    expect(fetchData).toHaveBeenCalledWith(
+      'https://test.test/v1/chains/4/data-decoder',
+      { data: '0x123' },
+    )
   })
 })


### PR DESCRIPTION
We can now clearly differentiate GET and POST endpoints by passing or not passing a `body` param.