### PR TITLE
fix: make `safeAppId` optional, add `messagesTag` + message endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -309,7 +309,7 @@ export function getSafeMessages(chainId: string, address: string, pageUrl?: stri
 /**
  * Returns a `SafeMessage`
  */
-export function getSafeMessage(chainId: string, messageHash: string): Promise<SafeMessage> {
+export function getSafeMessage(chainId: string, messageHash: string): Promise<Omit<SafeMessage, 'type'>> {
   return getEndpoint(baseUrl, '/v1/chains/{chainId}/messages/{message_hash}', {
     path: { chainId, message_hash: messageHash },
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import type { ChainListResponse, ChainInfo } from './types/chains'
 import type { SafeAppsResponse } from './types/safe-apps'
 import type { MasterCopyReponse } from './types/master-copies'
 import type { DecodedDataResponse } from './types/decoded-data'
-import type { SafeMessageListPage } from './types/safe-messages'
+import type { SafeMessage, SafeMessageListPage } from './types/safe-messages'
 import { DEFAULT_BASE_URL } from './config'
 
 export * from './types/safe-info'
@@ -304,6 +304,15 @@ export function getSafeMessages(chainId: string, address: string, pageUrl?: stri
     { path: { chainId, safe_address: address }, query: {} },
     pageUrl,
   )
+}
+
+/**
+ * Returns a `SafeMessage`
+ */
+export function getSafeMessage(chainId: string, messageHash: string): Promise<SafeMessage> {
+  return getEndpoint(baseUrl, '/v1/chains/{chainId}/messages/{message_hash}', {
+    path: { chainId, message_hash: messageHash },
+  })
 }
 
 /**

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -20,7 +20,12 @@ import type { ChainListResponse, ChainInfo } from './chains'
 import type { SafeAppsResponse } from './safe-apps'
 import type { DecodedDataRequest, DecodedDataResponse } from './decoded-data'
 import type { MasterCopyReponse } from './master-copies'
-import type { ConfirmSafeMessageRequest, ProposeSafeMessageRequest, SafeMessageListPage } from './safe-messages'
+import type {
+  ConfirmSafeMessageRequest,
+  ProposeSafeMessageRequest,
+  SafeMessage,
+  SafeMessageListPage,
+} from './safe-messages'
 
 export type Primitive = string | number | boolean | null
 
@@ -234,6 +239,15 @@ export interface paths extends PathRegistry {
       path: {
         chainId: string
         safe_address: string
+      }
+    }
+  }
+  '/v1/chains/{chainId}/messages/{message_hash}': {
+    get: operations['get_safe_message']
+    parameters: {
+      path: {
+        chainId: string
+        message_hash: string
       }
     }
   }
@@ -608,6 +622,19 @@ export interface operations {
     responses: {
       200: {
         schema: SafeMessageListPage
+      }
+    }
+  }
+  get_safe_message: {
+    parameters: {
+      path: {
+        chainId: string
+        message_hash: string
+      }
+    }
+    responses: {
+      200: {
+        schema: SafeMessage
       }
     }
   }

--- a/src/types/safe-info.ts
+++ b/src/types/safe-info.ts
@@ -20,4 +20,5 @@ export type SafeInfo = {
   collectiblesTag: string
   txQueuedTag: string
   txHistoryTag: string
+  messagesTag: string
 }

--- a/src/types/safe-messages.ts
+++ b/src/types/safe-messages.ts
@@ -63,7 +63,7 @@ export type SafeMessageListPage = Page<SafeMessageListItem>
 
 export type ProposeSafeMessageRequest = {
   message: SafeMessage['message']
-  safeAppId: number
+  safeAppId?: number
   signature: string
 }
 


### PR DESCRIPTION
## What it solves

1. Marks `safeAppId` as optional (which matches that of the transaction service and the gateway [here](https://github.com/safe-global/safe-client-gateway/pull/1020)). No `safeAppId` is present when testing adding a custom app.
2. Adds `getSafeMessage` endpoint for retrieving a `SafeMessage` by hash. It does not return a `type` [as seen here](https://github.com/safe-global/safe-client-gateway/pull/1019).
3. Adds `messagesTag` to Safe info endpoint (as seen [here](https://github.com/safe-global/safe-client-gateway/pull/1013)).