### PR TITLE
fix: prevent parsing empty responses from throwing

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,8 +61,8 @@ export async function fetchData<T>(url: string, body?: unknown): Promise<T> {
   try {
     json = await resp.json()
   } catch {
-    if (resp.headers && resp.headers.get('content-length') === '0') {
-      throw new Error('Empty response. ' + resp.statusText)
+    if (resp.headers && resp.headers.get('content-length') !== '0') {
+      throw new Error(`Invalid response content: ${resp.statusText}`)
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,7 +51,13 @@ export async function fetchData<T>(url: string, body?: unknown): Promise<T> {
   }
 
   const resp = await fetch(url, options)
-  const json = await resp.json()
+  let json
+
+  try {
+    json = await resp.json()
+  } catch {
+    // ignore
+  }
 
   if (!resp.ok) {
     let errTxt = ''

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,7 +62,7 @@ export async function fetchData<T>(url: string, body?: unknown): Promise<T> {
     json = await resp.json()
   } catch {
     if (resp.headers && resp.headers.get('content-length') === '0') {
-      throw new Error('Invalid response content')
+      throw new Error('Empty response. ' + resp.statusText)
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -67,15 +67,7 @@ export async function fetchData<T>(url: string, body?: unknown): Promise<T> {
   }
 
   if (!resp.ok) {
-    let errTxt = ''
-    try {
-      if (!isErrorResponse(json)) {
-        throw
-      }
-      errTxt = `${json.code}: ${json.message}`
-    } catch (e) {
-      errTxt = resp.statusText
-    }
+    const errTxt = isErrorResponse(json) ? `${json.code}: ${json.message}` : resp.statusText
     throw new Error(errTxt)
   }
 


### PR DESCRIPTION
## What it solves

Empty respones from thorwing on parse.

## How this PR fixes it

When `json()` is called on the `fetch` response, it is caught. It would otherwise throw if there is no response JSON to parse.

The endpoints in question which caused this error are the proposal/confirmation of Safe messages.