### PR TITLE
fix: adjust types for unsupported base contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-gateway-typescript-sdk",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/safe-info.ts
+++ b/src/types/safe-info.ts
@@ -3,6 +3,7 @@ import type { AddressEx } from './common'
 export enum ImplementationVersionState {
   UP_TO_DATE = 'UP_TO_DATE',
   OUTDATED = 'OUTDATED',
+  UNKNOWN = 'UNKNOWN',
 }
 
 export type SafeInfo = {
@@ -16,7 +17,7 @@ export type SafeInfo = {
   modules: AddressEx[] | null
   guard: AddressEx | null
   fallbackHandler: AddressEx
-  version: string
+  version: string | null
   collectiblesTag: string
   txQueuedTag: string
   txHistoryTag: string


### PR DESCRIPTION
## What it solves

https://github.com/safe-global/web-core/issues/1327 partially

## How this PR fixes it

When a Safe is created with an unknown base contract, the gateway returns a `null` `version` and an `UNKNOWN` `implementationVersionState`.

This sets `SafeInfo['version']` to `string | null` and the `ImplementationVersionState` has been extended to include the `UNKNOWN` option.

## How to test it

[Here](https://safe-client.staging.5afe.dev/v1/chains/137/safes/0xF3aa45696f8Bc702D41d11b365C067f26f79fcaA) is a reference Safe.