### PR TITLE
Chore: replace deprecated set-output in the deploy workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           NEW_VERSION=v$(node -p 'require("./package.json").version')
           if [ $NEW_VERSION != $OLD_VERSION ]; then
             echo "New version $NEW_VERSION detected"
-            echo "::set-output name=version::$NEW_VERSION"
+            echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
             git log "$OLD_VERSION"..HEAD --pretty=format:"* %s" > CHANGELOG.md
           else
             echo "Version $OLD_VERSION hasn't changed, skipping the release"


### PR DESCRIPTION
## What it solves

`set-output` will be deprecated in May this year, so we need to migrate it as per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I've copied this portion of the code from [web-core](https://github.com/safe-global/web-core/blob/dev/.github/workflows/tag-release.yml#L24), where it has worked well for a while, so I assume it will work here as well.