### PR TITLE
fix: Change type of data to be optional

### DIFF
--- a/src/types/decoded-data.ts
+++ b/src/types/decoded-data.ts
@@ -14,7 +14,7 @@ export type DecodedDataParameterValue = {
   operation: 0 | 1
   to: string
   value: string
-  data: string
+  data?: string
   dataDecoded?: {
     method: string
     parameters: DecodedDataBasicParameter[]


### PR DESCRIPTION
## What it solves

Part of [#1890](https://github.com/safe-global/web-core/issues/1890)

`valueDecoded.data` can be null and should be reflected in the type. For the sake of consistency with changes from #81 I changed the type to be optional instead of explicitely null.

## Examples

Tx Service: https://safe-transaction-goerli.safe.global/api/v1/multisig-transactions/0x4383f5cbddee358aa1e44023874ba63b751df6ba445c494d5799ddc48eeb42ae/

CGW: https://safe-client.safe.global/v1/chains/5/transactions/multisig_0x7a9af6Ef9197041A5841e84cB27873bEBd3486E2_0x4383f5cbddee358aa1e44023874ba63b751df6ba445c494d5799ddc48eeb42ae