### PR TITLE
fix: Update transaction data property to be nullable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-gateway-typescript-sdk",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -11,7 +11,7 @@ export type InternalTransaction = {
   operation: Operation
   to: string
   value?: string
-  data?: string
+  data: string | null
   dataDecoded?: DataDecoded
 }
 


### PR DESCRIPTION
## What it solves

Part of https://github.com/safe-global/web-core/issues/1890

In #117, we updated the type for `data` in `DecodedDataResponse` to be nullable but the corresponding type `DataDecoded` still had `data` to be optional which causes a type mismatch.

## How it solves it

- Update `data` in `DataDecoded` to be `string | null`