### PR TITLE
fix: improve `getSafeMessage ` return type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -309,7 +309,7 @@ export function getSafeMessages(chainId: string, address: string, pageUrl?: stri
 /**
  * Returns a `SafeMessage`
  */
-export function getSafeMessage(chainId: string, messageHash: string): Promise<Omit<SafeMessage, 'type'>> {
+export function getSafeMessage(chainId: string, messageHash: string): Promise<SafeMessage> {
   return getEndpoint(baseUrl, '/v1/chains/{chainId}/messages/{message_hash}', {
     path: { chainId, message_hash: messageHash },
   })


### PR DESCRIPTION
The return type from `getSafeMessage` could be narrowed.
This way, the endpoint can be used without having to cast the return type. See https://github.com/safe-global/web-core/pull/1874#discussion_r1171048448

_I've tested the modification in `web-core`_