### PR TITLE
Add optional to param to getDecodedData

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-gateway-typescript-sdk",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,10 +288,11 @@ export function getMasterCopies(chainId: string): Promise<MasterCopyReponse> {
 export function getDecodedData(
   chainId: string,
   encodedData: operations['data_decoder']['parameters']['body']['data'],
+  to: operations['data_decoder']['parameters']['body']['to'],
 ): Promise<DecodedDataResponse> {
   return postEndpoint(baseUrl, '/v1/chains/{chainId}/data-decoder', {
     path: { chainId: chainId },
-    body: { data: encodedData },
+    body: { data: encodedData, to },
   })
 }
 

--- a/src/types/decoded-data.ts
+++ b/src/types/decoded-data.ts
@@ -1,5 +1,6 @@
 export type DecodedDataRequest = {
   data: string
+  to?: string
 }
 
 type ParamValue = string | ParamValue[]


### PR DESCRIPTION
## What it solves

The CGW allows an optional `to` parameter for the `data-decoder` request so we should have it here as well.