### PR TITLE
feat: fixed EIP-1559 gasprice

### DIFF
--- a/src/types/chains.ts
+++ b/src/types/chains.ts
@@ -32,7 +32,7 @@ export type Theme = {
 export enum GAS_PRICE_TYPE {
   ORACLE = 'ORACLE',
   FIXED = 'FIXED',
-  FIXED_EIP1559 = "FIXED_EIP1559",
+  FIXED_1559 = 'FIXED1559',
   UNKNOWN = 'UNKNOWN',
 }
 
@@ -49,8 +49,8 @@ export type GasPriceFixed = {
 }
 
 export type GasPriceFixedEIP1559 = {
-  type: GAS_PRICE_TYPE.FIXED_EIP1559,
-  maxFeePerGas: string,
+  type: GAS_PRICE_TYPE.FIXED_1559
+  maxFeePerGas: string
   maxPriorityFeePerGas: string
 }
 

--- a/src/types/chains.ts
+++ b/src/types/chains.ts
@@ -32,6 +32,7 @@ export type Theme = {
 export enum GAS_PRICE_TYPE {
   ORACLE = 'ORACLE',
   FIXED = 'FIXED',
+  FIXED_EIP1559 = "FIXED_EIP1559",
   UNKNOWN = 'UNKNOWN',
 }
 
@@ -47,11 +48,17 @@ export type GasPriceFixed = {
   weiValue: string
 }
 
+export type GasPriceFixedEIP1559 = {
+  type: GAS_PRICE_TYPE.FIXED_EIP1559,
+  maxFeePerGas: string,
+  maxPriorityFeePerGas: string
+}
+
 export type GasPriceUnknown = {
   type: GAS_PRICE_TYPE.UNKNOWN
 }
 
-export type GasPrice = (GasPriceOracle | GasPriceFixed | GasPriceUnknown)[]
+export type GasPrice = (GasPriceOracle | GasPriceFixed | GasPriceFixedEIP1559 | GasPriceUnknown)[]
 
 export enum FEATURES {
   ERC721 = 'ERC721',


### PR DESCRIPTION
Enabled a new way of chain config for fixed EIP-1559 gas prices.

Required for https://github.com/safe-global/safe-wallet-web/issues/2222

Using this we can set 0.1 gwei `maxFeePerGas` and 0.0001 gwei `maxPriorityFeePerGas` on Optimism.

