### PR TITLE
feat: add notification (un-)registration endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-gateway-typescript-sdk",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,4 +1,4 @@
-import { fetchData, insertParams, stringifyQuery } from './utils'
+import { deleteData, fetchData, insertParams, stringifyQuery } from './utils'
 import type { DeleteEndpoint, GetEndpoint, paths, PostEndpoint, Primitive } from './types/api'
 
 function makeUrl(
@@ -40,5 +40,5 @@ export function deleteEndpoint<T extends keyof paths>(
   params?: paths[T] extends DeleteEndpoint ? paths[T]['delete']['parameters'] : never,
 ): Promise<paths[T] extends DeleteEndpoint ? paths[T]['delete']['responses'][200]['schema'] : never> {
   const url = makeUrl(baseUrl, path as string, params?.path)
-  return fetchData(url)
+  return deleteData(url)
 }

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,5 +1,5 @@
 import { fetchData, insertParams, stringifyQuery } from './utils'
-import type { GetEndpoint, paths, PostEndpoint, Primitive } from './types/api'
+import type { DeleteEndpoint, GetEndpoint, paths, PostEndpoint, Primitive } from './types/api'
 
 function makeUrl(
   baseUrl: string,
@@ -31,5 +31,14 @@ export function getEndpoint<T extends keyof paths>(
     return fetchData(rawUrl)
   }
   const url = makeUrl(baseUrl, path as string, params?.path, params?.query)
+  return fetchData(url)
+}
+
+export function deleteEndpoint<T extends keyof paths>(
+  baseUrl: string,
+  path: T,
+  params?: paths[T] extends DeleteEndpoint ? paths[T]['delete']['parameters'] : never,
+): Promise<paths[T] extends DeleteEndpoint ? paths[T]['delete']['responses'][200]['schema'] : never> {
+  const url = makeUrl(baseUrl, path as string, params?.path)
   return fetchData(url)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -358,7 +358,7 @@ export function getDelegates(chainId: string, query: DelegatesRequest = {}): Pro
 /**
  * Registers a device/Safe for notifications
  */
-export function registerNotifications(body: operations['register_notifications']['parameters']['body']): Promise<void> {
+export function registerDevice(body: operations['register_device']['parameters']['body']): Promise<void> {
   return postEndpoint(baseUrl, '/v1/register/notifications', {
     body,
   })
@@ -367,7 +367,7 @@ export function registerNotifications(body: operations['register_notifications']
 /**
  * Unregisters a Safe from notifications
  */
-export function unregisterSafeNotifications(chainId: string, address: string, uuid: string): Promise<void> {
+export function unregisterSafe(chainId: string, address: string, uuid: string): Promise<void> {
   return deleteEndpoint(baseUrl, '/v1/chains/{chainId}/notifications/devices/{uuid}/safes/{safe_address}', {
     path: { chainId, safe_address: address, uuid },
   })
@@ -376,7 +376,7 @@ export function unregisterSafeNotifications(chainId: string, address: string, uu
 /**
  * Unregisters a device from notifications
  */
-export function unregisterDeviceNotifications(chainId: string, uuid: string): Promise<void> {
+export function unregisterDevice(chainId: string, uuid: string): Promise<void> {
   return deleteEndpoint(baseUrl, '/v1/chains/{chainId}/notifications/devices/{uuid}', {
     path: { chainId, uuid },
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { getEndpoint, postEndpoint } from './endpoint'
+import { deleteEndpoint, getEndpoint, postEndpoint } from './endpoint'
 import type { operations } from './types/api'
 import type {
   SafeTransactionEstimation,
@@ -352,6 +352,33 @@ export function getDelegates(chainId: string, query: DelegatesRequest = {}): Pro
   return getEndpoint(baseUrl, '/v1/chains/{chainId}/delegates', {
     path: { chainId },
     query,
+  })
+}
+
+/**
+ * Registers a device/Safe for notifications
+ */
+export function registerNotifications(body: operations['register_notifications']['parameters']['body']): Promise<void> {
+  return postEndpoint(baseUrl, '/v1/register/notifications', {
+    body,
+  })
+}
+
+/**
+ * Unregisters a Safe from notifications
+ */
+export function unregisterSafeNotifications(chainId: string, address: string, uuid: string): Promise<void> {
+  return deleteEndpoint(baseUrl, '/v1/chains/{chainId}/notifications/devices/{uuid}/safes/{safe_address}', {
+    path: { chainId, safe_address: address, uuid },
+  })
+}
+
+/**
+ * Unregisters a device from notifications
+ */
+export function unregisterDeviceNotifications(chainId: string, uuid: string): Promise<void> {
+  return deleteEndpoint(baseUrl, '/v1/chains/{chainId}/notifications/devices/{uuid}', {
+    path: { chainId, uuid },
   })
 }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -31,11 +31,11 @@ import type { RegisterNotificationsRequest } from './notifications'
 
 export type Primitive = string | number | boolean | null
 
-interface DeleteParams {
+interface Params {
   path?: { [key: string]: Primitive }
 }
 
-interface GetParams extends DeleteParams {
+interface GetParams extends Params {
   query?: { [key: string]: Primitive }
 }
 
@@ -70,13 +70,13 @@ export interface PostEndpoint extends Endpoint {
 
 export interface DeleteEndpoint extends Endpoint {
   delete: {
-    parameters: DeleteParams | null
+    parameters: Params | null
     responses: Responses
   }
 }
 
 interface PathRegistry {
-  [key: string]: DeleteEndpoint | GetEndpoint | PostEndpoint | (GetEndpoint & PostEndpoint)
+  [key: string]: GetEndpoint | PostEndpoint | (GetEndpoint & PostEndpoint) | DeleteEndpoint
 }
 
 export interface paths extends PathRegistry {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -27,11 +27,15 @@ import type {
   SafeMessageListPage,
 } from './safe-messages'
 import type { DelegateResponse, DelegatesRequest } from './delegates'
+import type { RegisterNotificationsRequest } from './notifications'
 
 export type Primitive = string | number | boolean | null
 
-interface GetParams {
+interface DeleteParams {
   path?: { [key: string]: Primitive }
+}
+
+interface GetParams extends DeleteParams {
   query?: { [key: string]: Primitive }
 }
 
@@ -64,8 +68,15 @@ export interface PostEndpoint extends Endpoint {
   }
 }
 
+export interface DeleteEndpoint extends Endpoint {
+  delete: {
+    parameters: DeleteParams | null
+    responses: Responses
+  }
+}
+
 interface PathRegistry {
-  [key: string]: GetEndpoint | PostEndpoint | (GetEndpoint & PostEndpoint)
+  [key: string]: DeleteEndpoint | GetEndpoint | PostEndpoint | (GetEndpoint & PostEndpoint)
 }
 
 export interface paths extends PathRegistry {
@@ -268,6 +279,29 @@ export interface paths extends PathRegistry {
         chainId: string
       }
       query: DelegatesRequest
+    }
+  }
+  '/v1/register/notifications': {
+    post: operations['register_notifications']
+    parameters: null
+  }
+  '/v1/chains/{chainId}/notifications/devices/{uuid}/safes/{safe_address}': {
+    delete: operations['unregister_safe_notifications']
+    parameters: {
+      path: {
+        uuid: string
+        chainId: string
+        safe_address: string
+      }
+    }
+  }
+  '/v1/chains/{chainId}/notifications/devices/{uuid}': {
+    delete: operations['unregister_device_notifications']
+    parameters: {
+      path: {
+        uuid: string
+        chainId: string
+      }
     }
   }
 }
@@ -686,6 +720,43 @@ export interface operations {
     responses: {
       200: {
         schema: DelegateResponse
+      }
+    }
+  }
+  register_notifications: {
+    parameters: {
+      body: RegisterNotificationsRequest
+    }
+    responses: {
+      200: {
+        schema: void
+      }
+    }
+  }
+  unregister_safe_notifications: {
+    parameters: {
+      path: {
+        uuid: string
+        chainId: string
+        safe_address: string
+      }
+    }
+    responses: {
+      200: {
+        schema: void
+      }
+    }
+  }
+  unregister_device_notifications: {
+    parameters: {
+      path: {
+        uuid: string
+        chainId: string
+      }
+    }
+    responses: {
+      200: {
+        schema: void
       }
     }
   }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -282,11 +282,11 @@ export interface paths extends PathRegistry {
     }
   }
   '/v1/register/notifications': {
-    post: operations['register_notifications']
+    post: operations['register_device']
     parameters: null
   }
   '/v1/chains/{chainId}/notifications/devices/{uuid}/safes/{safe_address}': {
-    delete: operations['unregister_safe_notifications']
+    delete: operations['unregister_safe']
     parameters: {
       path: {
         uuid: string
@@ -296,7 +296,7 @@ export interface paths extends PathRegistry {
     }
   }
   '/v1/chains/{chainId}/notifications/devices/{uuid}': {
-    delete: operations['unregister_device_notifications']
+    delete: operations['unregister_device']
     parameters: {
       path: {
         uuid: string
@@ -723,7 +723,7 @@ export interface operations {
       }
     }
   }
-  register_notifications: {
+  register_device: {
     parameters: {
       body: RegisterNotificationsRequest
     }
@@ -733,7 +733,7 @@ export interface operations {
       }
     }
   }
-  unregister_safe_notifications: {
+  unregister_safe: {
     parameters: {
       path: {
         uuid: string
@@ -747,7 +747,7 @@ export interface operations {
       }
     }
   }
-  unregister_device_notifications: {
+  unregister_device: {
     parameters: {
       path: {
         uuid: string

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -1,0 +1,22 @@
+export enum DeviceType {
+  ANDROID = 'ANDROID',
+  IOS = 'IOS',
+  WEB = 'WEB',
+}
+
+type SafeRegistration = {
+  chainId: string
+  safes: Array<string>
+  signatures: Array<string>
+}
+
+export type RegisterNotificationsRequest = {
+  uuid: string
+  cloudMessagingToken: string
+  buildNumber: string
+  bundle: string
+  deviceType: DeviceType
+  version: string
+  timestamp: string
+  safeRegistrations: Array<SafeRegistration>
+}

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -11,12 +11,12 @@ type SafeRegistration = {
 }
 
 export type RegisterNotificationsRequest = {
-  uuid: string
+  uuid?: string
   cloudMessagingToken: string
   buildNumber: string
   bundle: string
   deviceType: DeviceType
   version: string
-  timestamp: string
+  timestamp?: string
   safeRegistrations: Array<SafeRegistration>
 }


### PR DESCRIPTION
This adds the device/Safe notification (un-)registration endpoints as per https://github.com/safe-global/safe-client-gateway-nest/pull/636:

- `/v1/register/notifications`
- `/v1/chains/{chainId}/notifications/devices/{uuid}/safes/{safe_address}`
- `/v1/chains/{chainId}/notifications/devices/{uuid}`