### PR TITLE
fix: re-export notification types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export * from './types/common'
 export * from './types/master-copies'
 export * from './types/decoded-data'
 export * from './types/safe-messages'
+export * from './types/notifications'
 
 // Can be set externally to a different CGW host
 let baseUrl: string = DEFAULT_BASE_URL


### PR DESCRIPTION
This re-exports the notification types for consistency.