### PR TITLE
Fix: getDecodedData "to" param should be optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -289,7 +289,7 @@ export function getMasterCopies(chainId: string): Promise<MasterCopyReponse> {
 export function getDecodedData(
   chainId: string,
   encodedData: operations['data_decoder']['parameters']['body']['data'],
-  to: operations['data_decoder']['parameters']['body']['to'],
+  to?: operations['data_decoder']['parameters']['body']['to'],
 ): Promise<DecodedDataResponse> {
   return postEndpoint(baseUrl, '/v1/chains/{chainId}/data-decoder', {
     path: { chainId: chainId },


### PR DESCRIPTION
It's typed as optional in the request type but not in the function signature.

(Introduced in #125.)