### PR TITLE
feat: add recommended nonce endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-gateway-typescript-sdk",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,6 +229,12 @@ export function postSafeGasEstimation(
   })
 }
 
+export function getRecommendedNonce(chainId: string, address: string): Promise<number> {
+  return getEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{safe_address}/recommended-nonce', {
+    path: { chainId, safe_address: address },
+  })
+}
+
 /**
  * Propose a new transaction for other owners to sign/execute
  */

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -304,6 +304,15 @@ export interface paths extends PathRegistry {
       }
     }
   }
+  '/v1/chains/{chainId}/safes/{safe_address}/recommended-nonce': {
+    get: operations['get_recommended_nonce']
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+      }
+    }
+  }
 }
 
 export interface operations {
@@ -757,6 +766,19 @@ export interface operations {
     responses: {
       200: {
         schema: void
+      }
+    }
+  }
+  get_recommended_nonce: {
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+      }
+    }
+    responses: {
+      200: {
+        schema: number
       }
     }
   }


### PR DESCRIPTION
## What it solves

Adds support for the new getRecommendedNonce endpoint (https://github.com/safe-global/safe-client-gateway/issues/681)

`GET /v1/chains/{chainId}/safes/{safe_address}/recommended-nonce`
