### PR TITLE
fix: recommended nonce response

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-gateway-typescript-sdk",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import type {
   SafeIncomingTransfersResponse,
   SafeModuleTransactionsResponse,
   SafeMultisigTransactionsResponse,
+  RecommendedNonceResponse,
 } from './types/transactions'
 import type {
   FiatCurrencies,
@@ -229,7 +230,7 @@ export function postSafeGasEstimation(
   })
 }
 
-export function getRecommendedNonce(chainId: string, address: string): Promise<number> {
+export function getRecommendedNonce(chainId: string, address: string): Promise<RecommendedNonceResponse> {
   return getEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{safe_address}/recommended-nonce', {
     path: { chainId, safe_address: address },
   })

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -14,6 +14,7 @@ import type {
   SafeIncomingTransfersResponse,
   SafeModuleTransactionsResponse,
   SafeMultisigTransactionsResponse,
+  RecommendedNonceResponse,
 } from './transactions'
 import type { SafeInfo } from './safe-info'
 import type { ChainListResponse, ChainInfo } from './chains'
@@ -778,7 +779,7 @@ export interface operations {
     }
     responses: {
       200: {
-        schema: number
+        schema: RecommendedNonceResponse
       }
     }
   }

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -406,6 +406,10 @@ export type SafeTransactionEstimation = {
   safeTxGas: string
 }
 
+export type RecommendedNonceResponse = {
+  nonce: number
+}
+
 /* Transaction estimation types end */
 
 export type SafeIncomingTransfersResponse = Page<IncomingTransfer>


### PR DESCRIPTION
## What it solves

Fixes the type introduced in #138 from a `number` to `{nonce: number}`