### PR TITLE
fix: Change getRecommendedNonce to getNonces call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-gateway-typescript-sdk",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import type {
   SafeIncomingTransfersResponse,
   SafeModuleTransactionsResponse,
   SafeMultisigTransactionsResponse,
-  RecommendedNonceResponse,
+  NoncesResponse,
 } from './types/transactions'
 import type {
   FiatCurrencies,
@@ -230,8 +230,8 @@ export function postSafeGasEstimation(
   })
 }
 
-export function getRecommendedNonce(chainId: string, address: string): Promise<RecommendedNonceResponse> {
-  return getEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{safe_address}/recommended-nonce', {
+export function getNonces(chainId: string, address: string): Promise<NoncesResponse> {
+  return getEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{safe_address}/nonces', {
     path: { chainId, safe_address: address },
   })
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -14,7 +14,7 @@ import type {
   SafeIncomingTransfersResponse,
   SafeModuleTransactionsResponse,
   SafeMultisigTransactionsResponse,
-  RecommendedNonceResponse,
+  NoncesResponse,
 } from './transactions'
 import type { SafeInfo } from './safe-info'
 import type { ChainListResponse, ChainInfo } from './chains'
@@ -305,8 +305,8 @@ export interface paths extends PathRegistry {
       }
     }
   }
-  '/v1/chains/{chainId}/safes/{safe_address}/recommended-nonce': {
-    get: operations['get_recommended_nonce']
+  '/v1/chains/{chainId}/safes/{safe_address}/nonces': {
+    get: operations['get_nonces']
     parameters: {
       path: {
         chainId: string
@@ -770,7 +770,7 @@ export interface operations {
       }
     }
   }
-  get_recommended_nonce: {
+  get_nonces: {
     parameters: {
       path: {
         chainId: string
@@ -779,7 +779,7 @@ export interface operations {
     }
     responses: {
       200: {
-        schema: RecommendedNonceResponse
+        schema: NoncesResponse
       }
     }
   }

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -406,8 +406,9 @@ export type SafeTransactionEstimation = {
   safeTxGas: string
 }
 
-export type RecommendedNonceResponse = {
-  nonce: number
+export type NoncesResponse = {
+  currentNonce: number
+  recommendedNonce: number
 }
 
 /* Transaction estimation types end */


### PR DESCRIPTION
## What it solves

Changes the existing function `getRecommendedNonce` to `getNonces` that returns both the current and recommended nonce according to the CGW: https://github.com/safe-global/safe-client-gateway/pull/817