### PR TITLE
Feat: add timezone_offset to tx list endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-gateway-typescript-sdk",
-  "version": "3.13.3",
+  "version": "3.14.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,13 +180,13 @@ export function getCollectiblesPage(
 export function getTransactionHistory(
   chainId: string,
   address: string,
+  query: operations['history_transactions']['parameters']['query'] = {},
   pageUrl?: string,
-  trusted?: boolean,
 ): Promise<TransactionListPage> {
   return getEndpoint(
     baseUrl,
     '/v1/chains/{chainId}/safes/{safe_address}/transactions/history',
-    { path: { chainId, safe_address: address }, query: { trusted } },
+    { path: { chainId, safe_address: address }, query },
     pageUrl,
   )
 }
@@ -197,13 +197,13 @@ export function getTransactionHistory(
 export function getTransactionQueue(
   chainId: string,
   address: string,
+  query: operations['queued_transactions']['parameters']['query'] = {},
   pageUrl?: string,
-  trusted?: boolean,
 ): Promise<TransactionListPage> {
   return getEndpoint(
     baseUrl,
     '/v1/chains/{chainId}/safes/{safe_address}/transactions/queued',
-    { path: { chainId, safe_address: address }, query: { trusted } },
+    { path: { chainId, safe_address: address }, query },
     pageUrl,
   )
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -376,6 +376,7 @@ export interface operations {
         to?: string
         token_address?: string
         value?: string
+        timezone_offset?: number
       }
     }
     responses: {
@@ -398,6 +399,7 @@ export interface operations {
       query?: {
         module?: string
         to?: string
+        timezone_offset?: number
       }
     }
     responses: {
@@ -424,6 +426,7 @@ export interface operations {
         value?: string
         nonce?: string
         executed?: string
+        timezone_offset?: number
       }
     }
     responses: {
@@ -501,6 +504,7 @@ export interface operations {
         /** Taken from the Page['next'] or Page['previous'] */
         page_url?: string
         trusted?: boolean
+        timezone_offset?: number
       }
     }
     responses: {
@@ -519,6 +523,7 @@ export interface operations {
         /** Taken from the Page['next'] or Page['previous'] */
         page_url?: string
         trusted?: boolean
+        timezone_offset?: number
       }
     }
     responses: {


### PR DESCRIPTION
All tx list endpoints now accept a `timezone_offset` query param (in milliseconds).

Breaking change:
* `getTransactionHistory` and `getTransactionQueue` signature change – they now take a query object _before_ the optional `pageUrl` argument.