### PR TITLE
Add `null` to `SafeInfo['collectiblesTag' | 'txQueuedTag' | 'txHistoryTag' | 'messagesTag']`

### DIFF
--- a/src/types/safe-info.ts
+++ b/src/types/safe-info.ts
@@ -18,8 +18,8 @@ export type SafeInfo = {
   guard: AddressEx | null
   fallbackHandler: AddressEx | null
   version: string | null
-  collectiblesTag: string
-  txQueuedTag: string
-  txHistoryTag: string
-  messagesTag: string
+  collectiblesTag: string | null
+  txQueuedTag: string | null
+  txHistoryTag: string | null
+  messagesTag: string | null
 }


### PR DESCRIPTION
This updates the `SafeInfo['collectiblesTag' | 'txQueuedTag' | 'txHistoryTag' | 'messagesTag']` in accordance with https://github.com/safe-global/safe-client-gateway/pull/909, returning `string | null`.