### PR TITLE
feat: Add getAllOwnedSafes endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import type {
   NoncesResponse,
 } from './types/transactions'
 import type {
+  AllOwnedSafes,
   FiatCurrencies,
   OwnedSafes,
   SafeBalanceResponse,
@@ -141,6 +142,13 @@ export function getFiatCurrencies(): Promise<FiatCurrencies> {
  */
 export function getOwnedSafes(chainId: string, address: string): Promise<OwnedSafes> {
   return getEndpoint(baseUrl, '/v1/chains/{chainId}/owners/{address}/safes', { path: { chainId, address } })
+}
+
+/**
+ * Get the addresses of all Safes belonging to an owner on all chains
+ */
+export function getAllOwnedSafes(address: string): Promise<AllOwnedSafes> {
+  return getEndpoint(baseUrl, '/v1/owners/{address}/safes', { path: { address } })
 }
 
 /**

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,4 +1,5 @@
 import type {
+  AllOwnedSafes,
   FiatCurrencies,
   OwnedSafes,
   SafeBalanceResponse,
@@ -205,6 +206,14 @@ export interface paths extends PathRegistry {
     parameters: {
       path: {
         chainId: string
+        address: string
+      }
+    }
+  }
+  '/v1/owners/{address}/safes': {
+    get: operations['get_all_owned_safes']
+    parameters: {
+      path: {
         address: string
       }
     }
@@ -591,6 +600,18 @@ export interface operations {
     responses: {
       200: {
         schema: OwnedSafes
+      }
+    }
+  }
+  get_all_owned_safes: {
+    parameters: {
+      path: {
+        address: string
+      }
+    }
+    responses: {
+      200: {
+        schema: AllOwnedSafes
       }
     }
   }

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -8,6 +8,8 @@ export type FiatCurrencies = string[]
 
 export type OwnedSafes = { safes: string[] }
 
+export type AllOwnedSafes = Record<string, string[]>
+
 export enum TokenType {
   ERC20 = 'ERC20',
   ERC721 = 'ERC721',


### PR DESCRIPTION
Add support for a new endpoint `getAllOwnedSafes` https://github.com/safe-global/safe-client-gateway/pull/1097

`GET /v1/owners/{address}/safes`