### PR TITLE
Add `chainLogoUri` to `ChainInfo`

### DIFF
--- a/src/types/chains.ts
+++ b/src/types/chains.ts
@@ -80,6 +80,7 @@ export type ChainInfo = {
   l2: boolean
   isTestnet: boolean
   description: string
+  chainLogoUri: string | null
   rpcUri: RpcUri
   safeAppsRpcUri: RpcUri
   publicRpcUri: RpcUri


### PR DESCRIPTION
This adds the new `ChainInfo['chainLogoUri']` in accordance with the recent release of the [Config Service](https://github.com/safe-global/safe-config-service/releases/tag/v2.71.0) and [Client Gateway](https://github.com/safe-global/safe-client-gateway/releases/tag/v1.26.0).