### PR TITLE
feat: register, change and verify email addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-gateway-typescript-sdk",
-  "version": "3.16.0",
+  "version": "3.17.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-gateway-typescript-sdk",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -18,7 +18,7 @@ export function postEndpoint<T extends keyof paths>(
   params?: paths[T] extends PostEndpoint ? paths[T]['post']['parameters'] : never,
 ): Promise<paths[T] extends PostEndpoint ? paths[T]['post']['responses'][200]['schema'] : never> {
   const url = makeUrl(baseUrl, path as string, params?.path, params?.query)
-  return fetchData(url, params?.body, params?.headers)
+  return fetchData(url, 'POST', params?.body, params?.headers)
 }
 
 export function putEndpoint<T extends keyof paths>(
@@ -27,7 +27,7 @@ export function putEndpoint<T extends keyof paths>(
   params?: paths[T] extends PutEndpoint ? paths[T]['put']['parameters'] : never,
 ): Promise<paths[T] extends PutEndpoint ? paths[T]['put']['responses'][200]['schema'] : never> {
   const url = makeUrl(baseUrl, path as string, params?.path, params?.query)
-  return fetchData(url, params?.body, params?.headers)
+  return fetchData(url, 'PUT', params?.body, params?.headers)
 }
 
 export function getEndpoint<T extends keyof paths>(
@@ -40,7 +40,7 @@ export function getEndpoint<T extends keyof paths>(
     return fetchData(rawUrl)
   }
   const url = makeUrl(baseUrl, path as string, params?.path, params?.query)
-  return fetchData(url, undefined, params?.headers)
+  return fetchData(url, undefined, undefined, params?.headers)
 }
 
 export function deleteEndpoint<T extends keyof paths>(

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,5 +1,5 @@
 import { deleteData, fetchData, insertParams, stringifyQuery } from './utils'
-import type { DeleteEndpoint, GetEndpoint, paths, PostEndpoint, Primitive } from './types/api'
+import type { DeleteEndpoint, GetEndpoint, paths, PostEndpoint, Primitive, PutEndpoint } from './types/api'
 
 function makeUrl(
   baseUrl: string,
@@ -18,7 +18,16 @@ export function postEndpoint<T extends keyof paths>(
   params?: paths[T] extends PostEndpoint ? paths[T]['post']['parameters'] : never,
 ): Promise<paths[T] extends PostEndpoint ? paths[T]['post']['responses'][200]['schema'] : never> {
   const url = makeUrl(baseUrl, path as string, params?.path, params?.query)
-  return fetchData(url, params?.body)
+  return fetchData(url, params?.body, params?.headers)
+}
+
+export function putEndpoint<T extends keyof paths>(
+  baseUrl: string,
+  path: T,
+  params?: paths[T] extends PutEndpoint ? paths[T]['put']['parameters'] : never,
+): Promise<paths[T] extends PutEndpoint ? paths[T]['put']['responses'][200]['schema'] : never> {
+  const url = makeUrl(baseUrl, path as string, params?.path, params?.query)
+  return fetchData(url, params?.body, params?.headers)
 }
 
 export function getEndpoint<T extends keyof paths>(
@@ -31,7 +40,7 @@ export function getEndpoint<T extends keyof paths>(
     return fetchData(rawUrl)
   }
   const url = makeUrl(baseUrl, path as string, params?.path, params?.query)
-  return fetchData(url)
+  return fetchData(url, undefined, params?.headers)
 }
 
 export function deleteEndpoint<T extends keyof paths>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { deleteEndpoint, getEndpoint, postEndpoint } from './endpoint'
+import { deleteEndpoint, getEndpoint, postEndpoint, putEndpoint } from './endpoint'
 import type { operations } from './types/api'
 import type {
   SafeTransactionEstimation,
@@ -410,6 +410,91 @@ export function unregisterSafe(chainId: string, address: string, uuid: string): 
 export function unregisterDevice(chainId: string, uuid: string): Promise<void> {
   return deleteEndpoint(baseUrl, '/v1/chains/{chainId}/notifications/devices/{uuid}', {
     path: { chainId, uuid },
+  })
+}
+
+/**
+ * Registers a email address for a safe signer.
+ *
+ * The signer wallet has to sign a message of format: `email-register-{chainId}-{safeAddress}-{emailAddress}-{signer}-{timestamp}`
+ * The signature is valid for 5 minutes.
+ *
+ * @param chainId
+ * @param safeAddress
+ * @param body Signer address and email address
+ * @param headers Signature and Signature timestamp
+ * @returns 200 if signature matches the data
+ */
+export function registerEmail(
+  chainId: string,
+  safeAddress: string,
+  body: operations['register_email']['parameters']['body'],
+  headers: operations['register_email']['parameters']['headers'],
+): Promise<void> {
+  return postEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{safe_address}/emails', {
+    path: { chainId, safe_address: safeAddress },
+    body,
+    headers,
+  })
+}
+
+/**
+ * Changes an already registered email address for a safe signer. The new email address still needs to be verified.
+ *
+ * The signer wallet has to sign a message of format: `email-edit-{chainId}-{safeAddress}-{emailAddress}-{signer}-{timestamp}`
+ * The signature is valid for 5 minutes.
+ *
+ * @param chainId
+ * @param safeAddress
+ * @param body New email address
+ * @param headers Signature and Signature timestamp
+ * @returns 202 if signature matches the data
+ */
+export function changeEmail(
+  chainId: string,
+  safeAddress: string,
+  signerAddress: string,
+  body: operations['change_email']['parameters']['body'],
+  headers: operations['change_email']['parameters']['headers'],
+): Promise<void> {
+  return putEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{safe_address}/emails/{signer}', {
+    path: { chainId, safe_address: safeAddress, signer: signerAddress },
+    body,
+    headers,
+  })
+}
+
+/**
+ * Resends an email verification code.
+ */
+export function resendEmailVerificationCode(
+  chainId: string,
+  safeAddress: string,
+  signerAddress: string,
+): Promise<void> {
+  return postEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{safe_address}/emails/{signer}/verify-resend', {
+    path: { chainId, safe_address: safeAddress, signer: signerAddress },
+    body: '',
+  })
+}
+
+/**
+ * Verifies a pending email address registration.
+ *
+ * @param chainId
+ * @param safeAddress
+ * @param signerAddress address who signed the email registration
+ * @param body Verification code
+ */
+export function verifyEmail(
+  chainId: string,
+  safeAddress: string,
+  signerAddress: string,
+  body: operations['verify_email']['parameters']['body'],
+): Promise<void> {
+  return putEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{safe_address}/emails/{signer}/verify', {
+    path: { chainId, safe_address: safeAddress, signer: signerAddress },
+    body,
   })
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -447,6 +447,7 @@ export function registerEmail(
  *
  * @param chainId
  * @param safeAddress
+ * @param signerAddress
  * @param body New email address
  * @param headers Signature and Signature timestamp
  * @returns 202 if signature matches the data
@@ -502,6 +503,9 @@ export function verifyEmail(
 /**
  * Gets the registered email address of the signer
  *
+ * The signer wallet will have to sign a message of format: `email-retrieval-{chainId}-{safe}-{signer}-{timestamp}`
+ * The signature is valid for 5 minutes.
+ *
  * @param chainId
  * @param safeAddress
  * @param signerAddress address of the owner of the Safe
@@ -522,6 +526,9 @@ export function getRegisteredEmail(
 
 /**
  * Delete a registered email address for the signer
+ *
+ * The signer wallet will have to sign a message of format: `email-delete-{chainId}-{safe}-{signer}-{timestamp}`
+ * The signature is valid for 5 minutes.
  *
  * @param chainId
  * @param safeAddress

--- a/src/index.ts
+++ b/src/index.ts
@@ -520,4 +520,24 @@ export function getRegisteredEmail(
   })
 }
 
+/**
+ * Delete a registered email address for the signer
+ *
+ * @param chainId
+ * @param safeAddress
+ * @param signerAddress
+ * @param headers
+ */
+export function deleteRegisteredEmail(
+  chainId: string,
+  safeAddress: string,
+  signerAddress: string,
+  headers: operations['delete_email']['parameters']['headers'],
+): Promise<void> {
+  return deleteEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{safe_address}/emails/{signer}', {
+    path: { chainId, safe_address: safeAddress, signer: signerAddress },
+    headers,
+  })
+}
+
 /* eslint-enable @typescript-eslint/explicit-module-boundary-types */

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import type { DecodedDataResponse } from './types/decoded-data'
 import type { SafeMessage, SafeMessageListPage } from './types/safe-messages'
 import { DEFAULT_BASE_URL } from './config'
 import type { DelegateResponse, DelegatesRequest } from './types/delegates'
+import type { GetEmailResponse } from './types/emails'
 
 export * from './types/safe-info'
 export * from './types/safe-apps'
@@ -495,6 +496,27 @@ export function verifyEmail(
   return putEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{safe_address}/emails/{signer}/verify', {
     path: { chainId, safe_address: safeAddress, signer: signerAddress },
     body,
+  })
+}
+
+/**
+ * Gets the registered email address of the signer
+ *
+ * @param chainId
+ * @param safeAddress
+ * @param signerAddress address of the owner of the Safe
+ *
+ * @returns email address and verified flag
+ */
+export function getRegisteredEmail(
+  chainId: string,
+  safeAddress: string,
+  signerAddress: string,
+  headers: operations['get_email']['parameters']['headers'],
+): Promise<GetEmailResponse> {
+  return getEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{safe_address}/emails/{signer}', {
+    path: { chainId, safe_address: safeAddress, signer: signerAddress },
+    headers,
   })
 }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -32,8 +32,9 @@ import type { DelegateResponse, DelegatesRequest } from './delegates'
 import type { RegisterNotificationsRequest } from './notifications'
 import type {
   ChangeEmailRequestBody,
+  GetEmailResponse,
   RegisterEmailRequestBody,
-  RegisterEmailRequestHeader,
+  AuthorizationEmailRequestHeader,
   VerifyEmailRequestBody,
 } from './emails'
 
@@ -92,7 +93,7 @@ export interface DeleteEndpoint extends Endpoint {
 }
 
 interface PathRegistry {
-  [key: string]: GetEndpoint | PostEndpoint | PutEndpoint | (GetEndpoint & PostEndpoint) | DeleteEndpoint
+  [key: string]: GetEndpoint | PostEndpoint | PutEndpoint | DeleteEndpoint
 }
 
 export interface paths extends PathRegistry {
@@ -357,6 +358,7 @@ export interface paths extends PathRegistry {
   }
   '/v1/chains/{chainId}/safes/{safe_address}/emails/{signer}': {
     put: operations['change_email']
+    get: operations['get_email']
     parameters: {
       path: {
         chainId: string
@@ -893,7 +895,7 @@ export interface operations {
         safe_address: string
       }
       body: RegisterEmailRequestBody
-      headers: RegisterEmailRequestHeader
+      headers: AuthorizationEmailRequestHeader
     }
     responses: {
       200: {
@@ -909,7 +911,7 @@ export interface operations {
         signer: string
       }
       body: ChangeEmailRequestBody
-      headers: RegisterEmailRequestHeader
+      headers: AuthorizationEmailRequestHeader
     }
     responses: {
       200: {
@@ -917,6 +919,21 @@ export interface operations {
       }
       202: {
         schema: void
+      }
+    }
+  }
+  get_email: {
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+        signer: string
+      }
+      headers: AuthorizationEmailRequestHeader
+    }
+    responses: {
+      200: {
+        schema: GetEmailResponse
       }
     }
   }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -30,11 +30,18 @@ import type {
 } from './safe-messages'
 import type { DelegateResponse, DelegatesRequest } from './delegates'
 import type { RegisterNotificationsRequest } from './notifications'
+import type {
+  ChangeEmailRequestBody,
+  RegisterEmailRequestBody,
+  RegisterEmailRequestHeader,
+  VerifyEmailRequestBody,
+} from './emails'
 
 export type Primitive = string | number | boolean | null
 
 interface Params {
   path?: { [key: string]: Primitive }
+  headers?: Record<string, string>
 }
 
 interface GetParams extends Params {
@@ -70,6 +77,13 @@ export interface PostEndpoint extends Endpoint {
   }
 }
 
+export interface PutEndpoint extends Endpoint {
+  put: {
+    parameters: PostParams | null
+    responses: Responses
+  }
+}
+
 export interface DeleteEndpoint extends Endpoint {
   delete: {
     parameters: Params | null
@@ -78,7 +92,7 @@ export interface DeleteEndpoint extends Endpoint {
 }
 
 interface PathRegistry {
-  [key: string]: GetEndpoint | PostEndpoint | (GetEndpoint & PostEndpoint) | DeleteEndpoint
+  [key: string]: GetEndpoint | PostEndpoint | PutEndpoint | (GetEndpoint & PostEndpoint) | DeleteEndpoint
 }
 
 export interface paths extends PathRegistry {
@@ -329,6 +343,45 @@ export interface paths extends PathRegistry {
       path: {
         chainId: string
         safe_address: string
+      }
+    }
+  }
+  '/v1/chains/{chainId}/safes/{safe_address}/emails': {
+    post: operations['register_email']
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+      }
+    }
+  }
+  '/v1/chains/{chainId}/safes/{safe_address}/emails/{signer}': {
+    put: operations['change_email']
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+        signer: string
+      }
+    }
+  }
+  '/v1/chains/{chainId}/safes/{safe_address}/emails/{signer}/verify-resend': {
+    post: operations['verify_resend']
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+        signer: string
+      }
+    }
+  }
+  '/v1/chains/{chainId}/safes/{safe_address}/emails/{signer}/verify': {
+    put: operations['verify_email']
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+        signer: string
       }
     }
   }
@@ -831,6 +884,80 @@ export interface operations {
       200: {
         schema: NoncesResponse
       }
+    }
+  }
+  register_email: {
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+      }
+      body: RegisterEmailRequestBody
+      headers: RegisterEmailRequestHeader
+    }
+    responses: {
+      200: {
+        schema: void
+      }
+    }
+  }
+  change_email: {
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+        signer: string
+      }
+      body: ChangeEmailRequestBody
+      headers: RegisterEmailRequestHeader
+    }
+    responses: {
+      200: {
+        schema: void
+      }
+      202: {
+        schema: void
+      }
+    }
+  }
+  verify_resend: {
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+        signer: string
+      }
+      body: ''
+    }
+    responses: {
+      202: {
+        schema: void
+      }
+      200: {
+        schema: void
+      }
+      429: unknown
+      409: unknown
+    }
+  }
+  verify_email: {
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+        signer: string
+      }
+      body: VerifyEmailRequestBody
+    }
+
+    responses: {
+      204: {
+        schema: void
+      }
+      200: {
+        schema: void
+      }
+      400: unknown
     }
   }
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -902,6 +902,9 @@ export interface operations {
       200: {
         schema: void
       }
+      201: {
+        schema: void
+      }
     }
   }
   change_email: {
@@ -954,8 +957,6 @@ export interface operations {
       200: {
         schema: void
       }
-      429: unknown
-      409: unknown
     }
   }
   verify_email: {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -359,6 +359,7 @@ export interface paths extends PathRegistry {
   '/v1/chains/{chainId}/safes/{safe_address}/emails/{signer}': {
     put: operations['change_email']
     get: operations['get_email']
+    delete: operations['delete_email']
     parameters: {
       path: {
         chainId: string
@@ -975,6 +976,26 @@ export interface operations {
         schema: void
       }
       400: unknown
+    }
+  }
+  delete_email: {
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+        signer: string
+      }
+      headers: AuthorizationEmailRequestHeader
+    }
+
+    responses: {
+      204: {
+        schema: void
+      }
+      200: {
+        schema: void
+      }
+      403: unknown
     }
   }
 }

--- a/src/types/emails.ts
+++ b/src/types/emails.ts
@@ -7,11 +7,16 @@ export type ChangeEmailRequestBody = {
   emailAddress: string
 }
 
-export type RegisterEmailRequestHeader = {
+export type AuthorizationEmailRequestHeader = {
   ['Safe-Wallet-Signature']: string
   ['Safe-Wallet-Signature-Timestamp']: string
 }
 
 export type VerifyEmailRequestBody = {
   code: string
+}
+
+export type GetEmailResponse = {
+  email: string
+  verified: boolean
 }

--- a/src/types/emails.ts
+++ b/src/types/emails.ts
@@ -1,0 +1,17 @@
+export type RegisterEmailRequestBody = {
+  emailAddress: string
+  signer: string
+}
+
+export type ChangeEmailRequestBody = {
+  emailAddress: string
+}
+
+export type RegisterEmailRequestHeader = {
+  ['Safe-Wallet-Signature']: string
+  ['Safe-Wallet-Signature-Timestamp']: string
+}
+
+export type VerifyEmailRequestBody = {
+  code: string
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,7 +56,7 @@ async function parseResponse<T>(resp: Response): Promise<T> {
   return json
 }
 
-export async function fetchData<T>(url: string, body?: unknown): Promise<T> {
+export async function fetchData<T>(url: string, body?: unknown, headers?: Record<string, string>): Promise<T> {
   let options:
     | {
         method: 'POST'
@@ -65,10 +65,12 @@ export async function fetchData<T>(url: string, body?: unknown): Promise<T> {
       }
     | undefined
   if (body != null) {
+    const requestHeaders: Record<string, string> = headers ?? {}
+    requestHeaders['Content-Type'] = 'application/json'
     options = {
       method: 'POST',
       body: typeof body === 'string' ? body : JSON.stringify(body),
-      headers: { 'Content-Type': 'application/json' },
+      headers: requestHeaders,
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,10 +56,15 @@ async function parseResponse<T>(resp: Response): Promise<T> {
   return json
 }
 
-export async function fetchData<T>(url: string, body?: unknown, headers?: Record<string, string>): Promise<T> {
+export async function fetchData<T>(
+  url: string,
+  method?: 'POST' | 'PUT',
+  body?: unknown,
+  headers?: Record<string, string>,
+): Promise<T> {
   let options:
     | {
-        method: 'POST'
+        method: 'POST' | 'PUT'
         headers: Record<string, string>
         body: string
       }
@@ -68,7 +73,7 @@ export async function fetchData<T>(url: string, body?: unknown, headers?: Record
     const requestHeaders: Record<string, string> = headers ?? {}
     requestHeaders['Content-Type'] = 'application/json'
     options = {
-      method: 'POST',
+      method: method ?? 'POST',
       body: typeof body === 'string' ? body : JSON.stringify(body),
       headers: requestHeaders,
     }

--- a/tests/endpoint.test.ts
+++ b/tests/endpoint.test.ts
@@ -148,7 +148,7 @@ describe('getEndpoint', () => {
     ).resolves.toEqual({ success: true })
 
     expect(fetchData).toHaveBeenCalledWith(
-      'https://test.test//v1/chains/4/safes/0x123/emails/0x456',
+      'https://test.test/v1/chains/4/safes/0x123/emails/0x456',
       'PUT',
       body,
       headers,

--- a/tests/endpoint.test.ts
+++ b/tests/endpoint.test.ts
@@ -1,5 +1,5 @@
 import { fetchData } from '../src/utils'
-import { getEndpoint, postEndpoint } from '../src/endpoint'
+import { getEndpoint, postEndpoint, putEndpoint } from '../src/endpoint'
 
 jest.mock('../src/utils', () => {
   const originalModule = jest.requireActual('../src/utils')
@@ -17,7 +17,12 @@ describe('getEndpoint', () => {
       success: true,
     })
 
-    expect(fetchData).toHaveBeenCalledWith('https://test.test/v1/balances/supported-fiat-codes')
+    expect(fetchData).toHaveBeenCalledWith(
+      'https://test.test/v1/balances/supported-fiat-codes',
+      undefined,
+      undefined,
+      undefined,
+    )
   })
 
   it('should accept a path param', async () => {
@@ -27,7 +32,7 @@ describe('getEndpoint', () => {
       }),
     ).resolves.toEqual({ success: true })
 
-    expect(fetchData).toHaveBeenCalledWith('https://test.test/v1/chains/4/safes/0x123')
+    expect(fetchData).toHaveBeenCalledWith('https://test.test/v1/chains/4/safes/0x123', undefined, undefined, undefined)
   })
 
   it('should accept several path params', async () => {
@@ -38,7 +43,12 @@ describe('getEndpoint', () => {
       }),
     ).resolves.toEqual({ success: true })
 
-    expect(fetchData).toHaveBeenCalledWith('https://test.test/v1/chains/4/safes/0x123/balances/usd')
+    expect(fetchData).toHaveBeenCalledWith(
+      'https://test.test/v1/chains/4/safes/0x123/balances/usd',
+      undefined,
+      undefined,
+      undefined,
+    )
   })
 
   it('should accept query params', async () => {
@@ -49,10 +59,15 @@ describe('getEndpoint', () => {
       }),
     ).resolves.toEqual({ success: true })
 
-    expect(fetchData).toHaveBeenCalledWith('https://test.test/v1/chains/4/safes/0x123/balances/usd?exclude_spam=true')
+    expect(fetchData).toHaveBeenCalledWith(
+      'https://test.test/v1/chains/4/safes/0x123/balances/usd?exclude_spam=true',
+      undefined,
+      undefined,
+      undefined,
+    )
   })
 
-  it('should accept body', async () => {
+  it('should accept POST request with body', async () => {
     const body = {
       to: '0x123',
       value: 'test',
@@ -77,7 +92,12 @@ describe('getEndpoint', () => {
       }),
     ).resolves.toEqual({ success: true })
 
-    expect(fetchData).toHaveBeenCalledWith('https://test.test/v1/chains/4/transactions/0x123/propose', body)
+    expect(fetchData).toHaveBeenCalledWith(
+      'https://test.test/v1/chains/4/transactions/0x123/propose',
+      'POST',
+      body,
+      undefined,
+    )
   })
 
   it('should accept a raw URL', async () => {
@@ -101,6 +121,37 @@ describe('getEndpoint', () => {
       }),
     ).resolves.toEqual({ success: true })
 
-    expect(fetchData).toHaveBeenCalledWith('https://test.test/v1/chains/4/data-decoder', { data: '0x123' })
+    expect(fetchData).toHaveBeenCalledWith(
+      'https://test.test/v1/chains/4/data-decoder',
+      'POST',
+      { data: '0x123' },
+      undefined,
+    )
+  })
+
+  it('should accept PUT request with body', async () => {
+    const body = {
+      emailAddress: 'test@test.com',
+    }
+
+    const headers = {
+      'Safe-Wallet-Signature': '0x234',
+      'Safe-Wallet-Signature-Timestamp': jest.now().toString(),
+    }
+
+    await expect(
+      putEndpoint('https://test.test', '/v1/chains/{chainId}/safes/{safe_address}/emails/{signer}', {
+        path: { chainId: '4', safe_address: '0x123', signer: '0x456' },
+        body,
+        headers,
+      }),
+    ).resolves.toEqual({ success: true })
+
+    expect(fetchData).toHaveBeenCalledWith(
+      'https://test.test//v1/chains/4/safes/0x123/emails/0x456',
+      'PUT',
+      body,
+      headers,
+    )
   })
 })

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -51,12 +51,54 @@ describe('utils', () => {
         })
       })
 
-      await expect(fetchData('/test/safe', '123')).resolves.toEqual({ success: true })
+      await expect(fetchData('/test/safe', 'POST', '123')).resolves.toEqual({ success: true })
 
       expect(fetch).toHaveBeenCalledWith('/test/safe', {
         method: 'POST',
         body: '123',
         headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+    })
+
+    it('should forward headers', async () => {
+      fetchMock.mockImplementation(() => {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve('{"success": "true"}'),
+          json: () => Promise.resolve({ success: true }),
+        })
+      })
+
+      await expect(fetchData('/test/safe', 'POST', '123', { TestHeader: '123456' })).resolves.toEqual({ success: true })
+
+      expect(fetch).toHaveBeenCalledWith('/test/safe', {
+        method: 'POST',
+        body: '123',
+        headers: {
+          TestHeader: '123456',
+          'Content-Type': 'application/json',
+        },
+      })
+    })
+
+    it('should use PUT if specified', async () => {
+      fetchMock.mockImplementation(() => {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve('{"success": "true"}'),
+          json: () => Promise.resolve({ success: true }),
+        })
+      })
+
+      await expect(fetchData('/test/safe', 'PUT', '123', { TestHeader: '123456' })).resolves.toEqual({ success: true })
+
+      expect(fetch).toHaveBeenCalledWith('/test/safe', {
+        method: 'PUT',
+        body: '123',
+        headers: {
+          TestHeader: '123456',
           'Content-Type': 'application/json',
         },
       })


### PR DESCRIPTION
## New Endpoints
- register email address for signer
- change email address for signer
- re-send verification code
- verify email address

## Other changes
- Some of the new endpoints require params in header fields. Therefore this PR adds header params to the api operations.

## Links
- [Spec](https://www.notion.so/safe-global/Emails-for-Recovery-7ab374774afd4ff9b484ddf9c627720e)