### PR TITLE
fix: Don't throw for 204 responses

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,7 +41,7 @@ async function parseResponse<T>(resp: Response): Promise<T> {
   let json
 
   try {
-    json = await resp.json()
+    json = resp.status === 204 ? {} : await resp.json()
   } catch {
     if (resp.headers && resp.headers.get('content-length') !== '0') {
       throw new Error(`Invalid response content: ${resp.statusText}`)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,6 +41,7 @@ async function parseResponse<T>(resp: Response): Promise<T> {
   let json
 
   try {
+    // An HTTP 204 - No Content response doesn't contain a body so trying to call .json() on it would throw
     json = resp.status === 204 ? {} : await resp.json()
   } catch {
     if (resp.headers && resp.headers.get('content-length') !== '0') {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -197,5 +197,26 @@ describe('utils', () => {
         },
       })
     })
+
+    it('should not throw for a 204 response', async () => {
+      const jsonMock = jest.fn()
+      fetchMock.mockImplementation(() => {
+        return Promise.resolve({
+          ok: true,
+          status: 204,
+          json: jsonMock,
+        })
+      })
+
+      await expect(fetchData('/test/safe', 'DELETE')).resolves.toEqual({})
+      expect(jsonMock).not.toHaveBeenCalled()
+
+      expect(fetch).toHaveBeenCalledWith('/test/safe', {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+    })
   })
 })


### PR DESCRIPTION
## What this solves

A 204 response doesn't contain a body so calling `response.json()` will throw. This is caught locally and we check if there is a `content-length: 0` header to cover the case of a 204 response. If there is no such header we throw again. The issue is that by default, the CGW returns 204 responses without such a header as it is not enforced.

To solve this we are explicitely checking for a 204 status and don't call `response.json()` in that case.