### PR TITLE
Add `trusted` query param. to `incoming-transfers` endpoint

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -484,6 +484,8 @@ export interface operations {
         address: string
       }
       query?: {
+        /** If `True` just trusted tokens will be returned */
+        trusted?: boolean
         execution_date__gte?: string
         execution_date__lte?: string
         to?: string


### PR DESCRIPTION
This adds the `trusted` query param. to the `incoming-transfers` endpoint in accordance with https://github.com/safe-global/safe-client-gateway/pull/1214.