### PR TITLE
feat: Add register module address endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -566,4 +566,21 @@ export function deleteRegisteredEmail(
   })
 }
 
+/**
+ * Register a recovery module for receiving alerts
+ * @param chainId
+ * @param safeAddress
+ * @param body - { moduleAddress: string }
+ */
+export function registerRecoveryModule(
+  chainId: string,
+  safeAddress: string,
+  body: operations['register_recovery_module']['parameters']['body'],
+): Promise<void> {
+  return postEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{safe_address}/recovery', {
+    path: { chainId, safe_address: safeAddress },
+    body,
+  })
+}
+
 /* eslint-enable @typescript-eslint/explicit-module-boundary-types */

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -38,6 +38,7 @@ import type {
   VerifyEmailRequestBody,
 } from './emails'
 import type { RelayCountResponse, RelayTransactionRequest, RelayTransactionResponse } from './relay'
+import type { RegisterRecoveryModuleRequestBody } from './recovery'
 
 export type Primitive = string | number | boolean | null
 
@@ -396,6 +397,15 @@ export interface paths extends PathRegistry {
         chainId: string
         safe_address: string
         signer: string
+      }
+    }
+  }
+  '/v1/chains/{chainId}/safes/{safe_address}/recovery': {
+    post: operations['register_recovery_module']
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
       }
     }
   }
@@ -1036,6 +1046,21 @@ export interface operations {
         schema: void
       }
       403: unknown
+    }
+  }
+  register_recovery_module: {
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+      }
+      body: RegisterRecoveryModuleRequestBody
+    }
+
+    responses: {
+      200: {
+        schema: void
+      }
     }
   }
 }

--- a/src/types/recovery.ts
+++ b/src/types/recovery.ts
@@ -1,0 +1,3 @@
+export type RegisterRecoveryModuleRequestBody = {
+  moduleAddress: string
+}


### PR DESCRIPTION
## What it solves

- Adds a new endpoint for `addRecoveryModule` ([CGW](https://github.com/safe-global/safe-client-gateway/blob/main/src/routes/recovery/recovery.controller.ts#L17))