### PR TITLE
feat: add `proposer` to `MultisigExecutionInfo`

### DIFF
--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -248,6 +248,7 @@ export type MultisigExecutionInfo = {
   confirmationsRequired: number
   confirmationsSubmitted: number
   missingSigners?: AddressEx[]
+  proposer: AddressEx | null
 }
 
 export type ExecutionInfo = ModuleExecutionInfo | MultisigExecutionInfo


### PR DESCRIPTION
This adds `MultisigExecutionInfo['proposer']` in accordance with https://github.com/safe-global/safe-client-gateway/pull/1217.