### PR TITLE
feat: Add unsubscribe endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -583,4 +583,20 @@ export function registerRecoveryModule(
   })
 }
 
+/**
+ * Delete email subscription for a single category
+ * @param query
+ */
+export function unsubscribeSingle(query: operations['unsubscribe_single']['parameters']['query']) {
+  return deleteEndpoint(baseUrl, '/v1/subscriptions', { query })
+}
+
+/**
+ * Delete email subscription for all categories
+ * @param query
+ */
+export function unsubscribeAll(query: operations['unsubscribe_all']['parameters']['query']) {
+  return deleteEndpoint(baseUrl, '/v1/subscriptions/all', { query })
+}
+
 /* eslint-enable @typescript-eslint/explicit-module-boundary-types */

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -59,7 +59,7 @@ interface Responses {
 
 interface Endpoint {
   parameters: {
-    path: Record<string, Primitive>
+    path: Record<string, Primitive> | null
   } | null
 }
 
@@ -406,6 +406,25 @@ export interface paths extends PathRegistry {
       path: {
         chainId: string
         safe_address: string
+      }
+    }
+  }
+  '/v1/subscriptions': {
+    delete: operations['unsubscribe_single']
+    parameters: {
+      path: null
+      query: {
+        category: string
+        token: string
+      }
+    }
+  }
+  '/v1/subscriptions/all': {
+    delete: operations['unsubscribe_all']
+    parameters: {
+      path: null
+      query: {
+        token: string
       }
     }
   }
@@ -1057,6 +1076,33 @@ export interface operations {
         safe_address: string
       }
       body: RegisterRecoveryModuleRequestBody
+    }
+
+    responses: {
+      200: {
+        schema: void
+      }
+    }
+  }
+  unsubscribe_single: {
+    parameters: {
+      query: {
+        category: string
+        token: string
+      }
+    }
+
+    responses: {
+      200: {
+        schema: void
+      }
+    }
+  }
+  unsubscribe_all: {
+    parameters: {
+      query: {
+        token: string
+      }
     }
 
     responses: {


### PR DESCRIPTION
## What it solves

Adds support for unsubscribe and unsubscribe all endpoints as described in the [API Spec](https://www.notion.so/safe-global/As-an-email-owner-I-want-to-be-able-to-unsubscribe-from-email-notifications-since-I-m-no-longer-int-d5f4491226844e3d9a982819b04bd27f).