### PR TITLE
feat: move `proposer` from `MultisigExecutionInfo` to `MultisigExecutionDetails`

### DIFF
--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -248,7 +248,6 @@ export type MultisigExecutionInfo = {
   confirmationsRequired: number
   confirmationsSubmitted: number
   missingSigners?: AddressEx[]
-  proposer: AddressEx | null
 }
 
 export type ExecutionInfo = ModuleExecutionInfo | MultisigExecutionInfo
@@ -374,6 +373,7 @@ export type MultisigExecutionDetails = {
   rejectors?: AddressEx[]
   gasTokenInfo?: TokenInfo
   trusted: boolean
+  proposer: AddressEx | null
 }
 
 export type DetailedExecutionInfo = ModuleExecutionDetails | MultisigExecutionDetails


### PR DESCRIPTION
This moves the `proposer` from the `executionInfo` to the `detailedExecutionInfo` of a multisig transaction [in accordance with the Gateway](https://github.com/safe-global/safe-client-gateway/pull/1234).