### PR TITLE
Feat: safe overviews endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import type {
   NoncesResponse,
 } from './types/transactions'
 import type {
+  EthereumAddress,
   AllOwnedSafes,
   FiatCurrencies,
   OwnedSafes,
@@ -17,7 +18,7 @@ import type {
   SafeCollectibleResponse,
   SafeCollectiblesPage,
 } from './types/common'
-import type { SafeInfo } from './types/safe-info'
+import type { SafeInfo, SafeOverview } from './types/safe-info'
 import type { ChainListResponse, ChainInfo } from './types/chains'
 import type { SafeAppsResponse } from './types/safe-apps'
 import type { MasterCopyReponse } from './types/master-copies'
@@ -597,6 +598,21 @@ export function unsubscribeSingle(query: operations['unsubscribe_single']['param
  */
 export function unsubscribeAll(query: operations['unsubscribe_all']['parameters']['query']) {
   return deleteEndpoint(baseUrl, '/v1/subscriptions/all', { query })
+}
+
+/**
+ * Get Safe overviews per address
+ */
+export function getSafeOverviews(
+  safes: `${number}:${EthereumAddress}`[],
+  query: Omit<operations['SafesController_getSafeOverview']['parameters']['query'], 'safes'>,
+): Promise<SafeOverview[]> {
+  return getEndpoint(baseUrl, '/v1/safes', {
+    query: {
+      ...query,
+      safes: safes.join(','),
+    },
+  })
 }
 
 /* eslint-enable @typescript-eslint/explicit-module-boundary-types */

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -17,7 +17,7 @@ import type {
   SafeMultisigTransactionsResponse,
   NoncesResponse,
 } from './transactions'
-import type { SafeInfo } from './safe-info'
+import type { SafeInfo, SafeOverview } from './safe-info'
 import type { ChainListResponse, ChainInfo } from './chains'
 import type { SafeAppsResponse } from './safe-apps'
 import type { DecodedDataRequest, DecodedDataResponse } from './decoded-data'
@@ -413,19 +413,18 @@ export interface paths extends PathRegistry {
     delete: operations['unsubscribe_single']
     parameters: {
       path: null
-      query: {
-        category: string
-        token: string
-      }
     }
   }
   '/v1/subscriptions/all': {
     delete: operations['unsubscribe_all']
     parameters: {
       path: null
-      query: {
-        token: string
-      }
+    }
+  }
+  '/v1/safes': {
+    get: operations['SafesController_getSafeOverview']
+    parameters: {
+      path: null
     }
   }
 }
@@ -1108,6 +1107,22 @@ export interface operations {
     responses: {
       200: {
         schema: void
+      }
+    }
+  }
+  SafesController_getSafeOverview: {
+    parameters: {
+      query: {
+        currency: string
+        safes: string
+        trusted: boolean
+        exclude_spam: boolean
+        walletAddress: string
+      }
+    }
+    responses: {
+      200: {
+        schema: SafeOverview[]
       }
     }
   }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1117,7 +1117,7 @@ export interface operations {
         safes: string
         trusted: boolean
         exclude_spam: boolean
-        walletAddress: string
+        walletAddress?: string
       }
     }
     responses: {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -58,3 +58,5 @@ export type SafeCollectibleResponse = {
 }
 
 export type SafeCollectiblesPage = Page<SafeCollectibleResponse>
+
+export type EthereumAddress = `0x${string}`

--- a/src/types/safe-info.ts
+++ b/src/types/safe-info.ts
@@ -23,3 +23,13 @@ export type SafeInfo = {
   txHistoryTag: string | null
   messagesTag: string | null
 }
+
+export type SafeOverview = {
+  address: AddressEx
+  chainId: string
+  threshold: number
+  owners: AddressEx[]
+  fiatTotal: string
+  queued: number
+  awaitingConfirmation: number
+}

--- a/src/types/safe-info.ts
+++ b/src/types/safe-info.ts
@@ -31,5 +31,5 @@ export type SafeOverview = {
   owners: AddressEx[]
   fiatTotal: string
   queued: number
-  awaitingConfirmation: number
+  awaitingConfirmation: number | null
 }


### PR DESCRIPTION
A new endpoint to get info, balances and pending tx counts for a list of safes.

Endpoint: https://safe-client.staging.5afe.dev/api#/safes/SafesController_getSafeOverview