### PR TITLE
feat: add confirmation view endpoint types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -295,6 +295,21 @@ export function proposeTransaction(
 }
 
 /**
+ * Returns decoded data
+ */
+export function getConfirmationView(
+  chainId: string,
+  safeAddress: string,
+  encodedData: operations['data_decoder']['parameters']['body']['data'],
+  to?: operations['data_decoder']['parameters']['body']['to'],
+): Promise<DecodedDataResponse> {
+  return postEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{safe_address}/views/transaction-confirmation', {
+    path: { chainId: chainId, safe_address: safeAddress },
+    body: { data: encodedData, to },
+  })
+}
+
+/**
  * Returns all defined chain configs
  */
 export function getChainsConfig(query?: operations['chains_list']['parameters']['query']): Promise<ChainListResponse> {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -20,7 +20,12 @@ import type {
 import type { SafeInfo, SafeOverview } from './safe-info'
 import type { ChainListResponse, ChainInfo } from './chains'
 import type { SafeAppsResponse } from './safe-apps'
-import type { DecodedDataRequest, DecodedDataResponse } from './decoded-data'
+import type {
+  BaselineConfirmationView,
+  CowSwapConfirmationView,
+  DecodedDataRequest,
+  DecodedDataResponse,
+} from './decoded-data'
 import type { MasterCopyReponse } from './master-copies'
 import type {
   ConfirmSafeMessageRequest,
@@ -54,6 +59,7 @@ interface BodyParams extends Params {
 
 interface Responses {
   200: { schema: unknown }
+
   [key: number]: { schema: unknown } | unknown
 }
 
@@ -230,6 +236,15 @@ export interface paths extends PathRegistry {
   }
   '/v1/chains/{chainId}/transactions/{safe_address}/propose': {
     post: operations['propose_transaction']
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+      }
+    }
+  }
+  '/v1/chains/{chainId}/safes/{safe_address}/views/transaction-confirmation': {
+    post: operations['get_transaction_confirmation_view']
     parameters: {
       path: {
         chainId: string
@@ -736,6 +751,21 @@ export interface operations {
       404: unknown
       /** Safe address checksum not valid */
       422: unknown
+    }
+  }
+  get_transaction_confirmation_view: {
+    parameters: {
+      path: {
+        /** A unique value identifying this chain. */
+        chainId: string
+        safe_address: string
+      }
+      body: DecodedDataRequest
+    }
+    responses: {
+      200: {
+        schema: BaselineConfirmationView | CowSwapConfirmationView
+      }
     }
   }
   get_owned_safes: {

--- a/src/types/decoded-data.ts
+++ b/src/types/decoded-data.ts
@@ -1,3 +1,5 @@
+import type { SwapOrder } from './transactions'
+
 export type DecodedDataRequest = {
   data: string
   to?: string
@@ -30,3 +32,10 @@ export type DecodedDataResponse = {
   method: string
   parameters: DecodedDataParameter[]
 }
+
+export type BaselineConfirmationView = {
+  type: 'GENERIC'
+} & DecodedDataResponse
+
+export type CowSwapConfirmationView = { type: 'COW_SWAP_ORDER' } & DecodedDataResponse &
+  Omit<SwapOrder, 'type' | 'humanDescription' | 'richDecodedInfo'>

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -260,7 +260,7 @@ export type SwapOrder = {
   uid: string
   status: OrderStatuses
   kind: OrderKind
-  class: OrderClass
+  orderClass: OrderClass
   /** @description The timestamp when the order expires */
   validUntil: number
   /** @description The sell token raw amount (no decimals) */

--- a/tests/endpoint.test.ts
+++ b/tests/endpoint.test.ts
@@ -118,6 +118,22 @@ describe('getEndpoint', () => {
     )
   })
 
+  it('should call a data decoder confirmation view POST endpoint', async () => {
+    await expect(
+      postEndpoint('https://test.test', '/v1/chains/{chainId}/safes/{safe_address}/views/transaction-confirmation', {
+        path: { chainId: '4', safe_address: '0x123' },
+        body: { data: '0x456' },
+      }),
+    ).resolves.toEqual({ success: true })
+
+    expect(fetchData).toHaveBeenCalledWith(
+      'https://test.test/v1/chains/4/safes/0x123/views/transaction-confirmation',
+      'POST',
+      { data: '0x456' },
+      undefined,
+    )
+  })
+
   it('should accept PUT request with body', async () => {
     const body = {
       emailAddress: 'test@test.com',


### PR DESCRIPTION
There is a new endpoint on the gateway for which we need types. It basically "replaces" the "data-decoder" endpoint and ads more info about for example "swaps". 