### PR TITLE
feat: add receiver prop to swap orders

### DIFF
--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -277,6 +277,8 @@ export type SwapOrder = {
   explorerUrl: string
   /** @description The amount of fees paid for this order. */
   executedSurplusFee?: string | null
+  /** @description The (optional) address to receive the proceeds of the trade */
+  receiver?: string | null
   /** @description The App Data for this order */
   fullAppData?: Record<string, unknown> | null
 }


### PR DESCRIPTION
The receiver prop was added on the cgw side, so reflecting in the type definition here.