### PR TITLE
Feat: add `balancesProvider` to chainInfo type

### DIFF
--- a/src/types/chains.ts
+++ b/src/types/chains.ts
@@ -91,6 +91,10 @@ export type ChainInfo = {
   gasPrice: GasPrice
   disabledWallets: string[]
   features: FEATURES[]
+  balancesProvider: {
+    chainName: string | null
+    enabled: boolean
+  }
 }
 
 export type ChainListResponse = Page<ChainInfo>


### PR DESCRIPTION
Adds a flag to chainInfo for whether zerion balances are supported on a chain. To be used for ERC20 balances of counterfactual safes.
Reflecting [changes to the CGW](https://github.com/safe-global/safe-client-gateway/pull/1648).
