### PR TITLE
Feat: add imitation property to Erc20Transfer type

### DIFF
--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -98,6 +98,7 @@ export type Erc20Transfer = {
   decimals?: number
   value: string
   trusted: boolean | null
+  imitation: boolean
 }
 
 export type Erc721Transfer = {


### PR DESCRIPTION
Add boolean imitation propert to ERC20Transfer to signify that a transfer is a malicious imitation of a legitimate transaction. 

Used for marking address poisoning attacks https://github.com/safe-global/safe-wallet-web/issues/3832