### PR TITLE
feat: Add siwe auth endpoints

### DIFF
--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -16,30 +16,27 @@ export function postEndpoint<T extends keyof paths>(
   baseUrl: string,
   path: T,
   params?: paths[T] extends PostEndpoint ? paths[T]['post']['parameters'] : never,
-  includeCredentials?: boolean,
 ): Promise<paths[T] extends PostEndpoint ? paths[T]['post']['responses'][200]['schema'] : never> {
   const url = makeUrl(baseUrl, path as string, params?.path, params?.query)
-  return fetchData(url, 'POST', params?.body, params?.headers, includeCredentials)
+  return fetchData(url, 'POST', params?.body, params?.headers, params?.credentials)
 }
 
 export function putEndpoint<T extends keyof paths>(
   baseUrl: string,
   path: T,
   params?: paths[T] extends PutEndpoint ? paths[T]['put']['parameters'] : never,
-  includeCredentials?: boolean,
 ): Promise<paths[T] extends PutEndpoint ? paths[T]['put']['responses'][200]['schema'] : never> {
   const url = makeUrl(baseUrl, path as string, params?.path, params?.query)
-  return fetchData(url, 'PUT', params?.body, params?.headers, includeCredentials)
+  return fetchData(url, 'PUT', params?.body, params?.headers, params?.credentials)
 }
 
 export function deleteEndpoint<T extends keyof paths>(
   baseUrl: string,
   path: T,
   params?: paths[T] extends DeleteEndpoint ? paths[T]['delete']['parameters'] : never,
-  includeCredentials?: boolean,
 ): Promise<paths[T] extends DeleteEndpoint ? paths[T]['delete']['responses'][200]['schema'] : never> {
   const url = makeUrl(baseUrl, path as string, params?.path, params?.query)
-  return fetchData(url, 'DELETE', params?.body, params?.headers, includeCredentials)
+  return fetchData(url, 'DELETE', params?.body, params?.headers, params?.credentials)
 }
 
 export function getEndpoint<T extends keyof paths>(
@@ -47,11 +44,10 @@ export function getEndpoint<T extends keyof paths>(
   path: T,
   params?: paths[T] extends GetEndpoint ? paths[T]['get']['parameters'] : never,
   rawUrl?: string,
-  includeCredentials?: boolean,
 ): Promise<paths[T] extends GetEndpoint ? paths[T]['get']['responses'][200]['schema'] : never> {
   if (rawUrl) {
-    return getData(rawUrl, undefined, includeCredentials)
+    return getData(rawUrl, undefined, params?.credentials)
   }
   const url = makeUrl(baseUrl, path as string, params?.path, params?.query)
-  return getData(url, params?.headers, includeCredentials)
+  return getData(url, params?.headers, params?.credentials)
 }

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -16,7 +16,7 @@ export function postEndpoint<T extends keyof paths>(
   baseUrl: string,
   path: T,
   params?: paths[T] extends PostEndpoint ? paths[T]['post']['parameters'] : never,
-  includeCredentials = false,
+  includeCredentials?: boolean,
 ): Promise<paths[T] extends PostEndpoint ? paths[T]['post']['responses'][200]['schema'] : never> {
   const url = makeUrl(baseUrl, path as string, params?.path, params?.query)
   return fetchData(url, 'POST', params?.body, params?.headers, includeCredentials)
@@ -26,7 +26,7 @@ export function putEndpoint<T extends keyof paths>(
   baseUrl: string,
   path: T,
   params?: paths[T] extends PutEndpoint ? paths[T]['put']['parameters'] : never,
-  includeCredentials = false,
+  includeCredentials?: boolean,
 ): Promise<paths[T] extends PutEndpoint ? paths[T]['put']['responses'][200]['schema'] : never> {
   const url = makeUrl(baseUrl, path as string, params?.path, params?.query)
   return fetchData(url, 'PUT', params?.body, params?.headers, includeCredentials)
@@ -36,7 +36,7 @@ export function deleteEndpoint<T extends keyof paths>(
   baseUrl: string,
   path: T,
   params?: paths[T] extends DeleteEndpoint ? paths[T]['delete']['parameters'] : never,
-  includeCredentials = false,
+  includeCredentials?: boolean,
 ): Promise<paths[T] extends DeleteEndpoint ? paths[T]['delete']['responses'][200]['schema'] : never> {
   const url = makeUrl(baseUrl, path as string, params?.path, params?.query)
   return fetchData(url, 'DELETE', params?.body, params?.headers, includeCredentials)
@@ -47,7 +47,7 @@ export function getEndpoint<T extends keyof paths>(
   path: T,
   params?: paths[T] extends GetEndpoint ? paths[T]['get']['parameters'] : never,
   rawUrl?: string,
-  includeCredentials = false,
+  includeCredentials?: boolean,
 ): Promise<paths[T] extends GetEndpoint ? paths[T]['get']['responses'][200]['schema'] : never> {
   if (rawUrl) {
     return getData(rawUrl, undefined, includeCredentials)

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -16,27 +16,30 @@ export function postEndpoint<T extends keyof paths>(
   baseUrl: string,
   path: T,
   params?: paths[T] extends PostEndpoint ? paths[T]['post']['parameters'] : never,
+  includeCredentials = false,
 ): Promise<paths[T] extends PostEndpoint ? paths[T]['post']['responses'][200]['schema'] : never> {
   const url = makeUrl(baseUrl, path as string, params?.path, params?.query)
-  return fetchData(url, 'POST', params?.body, params?.headers)
+  return fetchData(url, 'POST', params?.body, params?.headers, includeCredentials)
 }
 
 export function putEndpoint<T extends keyof paths>(
   baseUrl: string,
   path: T,
   params?: paths[T] extends PutEndpoint ? paths[T]['put']['parameters'] : never,
+  includeCredentials = false,
 ): Promise<paths[T] extends PutEndpoint ? paths[T]['put']['responses'][200]['schema'] : never> {
   const url = makeUrl(baseUrl, path as string, params?.path, params?.query)
-  return fetchData(url, 'PUT', params?.body, params?.headers)
+  return fetchData(url, 'PUT', params?.body, params?.headers, includeCredentials)
 }
 
 export function deleteEndpoint<T extends keyof paths>(
   baseUrl: string,
   path: T,
   params?: paths[T] extends DeleteEndpoint ? paths[T]['delete']['parameters'] : never,
+  includeCredentials = false,
 ): Promise<paths[T] extends DeleteEndpoint ? paths[T]['delete']['responses'][200]['schema'] : never> {
   const url = makeUrl(baseUrl, path as string, params?.path, params?.query)
-  return fetchData(url, 'DELETE', params?.body, params?.headers)
+  return fetchData(url, 'DELETE', params?.body, params?.headers, includeCredentials)
 }
 
 export function getEndpoint<T extends keyof paths>(
@@ -44,10 +47,11 @@ export function getEndpoint<T extends keyof paths>(
   path: T,
   params?: paths[T] extends GetEndpoint ? paths[T]['get']['parameters'] : never,
   rawUrl?: string,
+  includeCredentials = false,
 ): Promise<paths[T] extends GetEndpoint ? paths[T]['get']['responses'][200]['schema'] : never> {
   if (rawUrl) {
-    return getData(rawUrl)
+    return getData(rawUrl, undefined, includeCredentials)
   }
   const url = makeUrl(baseUrl, path as string, params?.path, params?.query)
-  return getData(url, params?.headers)
+  return getData(url, params?.headers, includeCredentials)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import type { DelegateResponse, DelegatesRequest } from './types/delegates'
 import type { GetEmailResponse } from './types/emails'
 import type { RelayCountResponse, RelayTransactionResponse } from './types/relay'
 import type { Contract } from './types/contracts'
+import type { AuthNonce } from './types/auth'
 
 export * from './types/safe-info'
 export * from './types/safe-apps'
@@ -638,6 +639,21 @@ export function getContract(chainId: string, contractAddress: string): Promise<C
       contractAddress: contractAddress,
     },
   })
+}
+
+export function getAuthNonce(): Promise<AuthNonce> {
+  return getEndpoint(baseUrl, '/v1/auth/nonce', undefined, undefined, true)
+}
+
+export function verifyAuth(body: operations['verify_auth']['parameters']['body']) {
+  return postEndpoint(
+    baseUrl,
+    '/v1/auth/verify',
+    {
+      body,
+    },
+    true,
+  )
 }
 
 /* eslint-enable @typescript-eslint/explicit-module-boundary-types */

--- a/src/index.ts
+++ b/src/index.ts
@@ -642,18 +642,14 @@ export function getContract(chainId: string, contractAddress: string): Promise<C
 }
 
 export function getAuthNonce(): Promise<AuthNonce> {
-  return getEndpoint(baseUrl, '/v1/auth/nonce', undefined, undefined, true)
+  return getEndpoint(baseUrl, '/v1/auth/nonce', { credentials: 'include' })
 }
 
 export function verifyAuth(body: operations['verify_auth']['parameters']['body']) {
-  return postEndpoint(
-    baseUrl,
-    '/v1/auth/verify',
-    {
-      body,
-    },
-    true,
-  )
+  return postEndpoint(baseUrl, '/v1/auth/verify', {
+    body,
+    credentials: 'include',
+  })
 }
 
 /* eslint-enable @typescript-eslint/explicit-module-boundary-types */

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -458,14 +458,14 @@ export interface paths extends PathRegistry {
     get: operations['get_auth_nonce']
     parameters: {
       path: null
-      credentials: RequestCredentials
+      credentials: 'include'
     }
   }
   '/v1/auth/verify': {
     post: operations['verify_auth']
     parameters: {
       path: null
-      credentials: RequestCredentials
+      credentials: 'include'
       body: {
         message: string
         signature: string
@@ -1201,7 +1201,7 @@ export interface operations {
   }
   get_auth_nonce: {
     parameters: {
-      credentials: RequestCredentials
+      credentials: 'include'
     }
     responses: {
       200: {
@@ -1215,7 +1215,7 @@ export interface operations {
         message: string
         signature: string
       }
-      credentials: RequestCredentials
+      credentials: 'include'
     }
     responses: {
       200: {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -53,6 +53,7 @@ interface Params {
   path?: { [key: string]: Primitive }
   headers?: Record<string, string>
   query?: { [key: string]: Primitive }
+  credentials?: RequestCredentials
 }
 
 interface BodyParams extends Params {
@@ -457,12 +458,14 @@ export interface paths extends PathRegistry {
     get: operations['get_auth_nonce']
     parameters: {
       path: null
+      credentials: RequestCredentials
     }
   }
   '/v1/auth/verify': {
     post: operations['verify_auth']
     parameters: {
       path: null
+      credentials: RequestCredentials
       body: {
         message: string
         signature: string
@@ -1197,7 +1200,9 @@ export interface operations {
     }
   }
   get_auth_nonce: {
-    parameters: null
+    parameters: {
+      credentials: RequestCredentials
+    }
     responses: {
       200: {
         schema: AuthNonce
@@ -1210,6 +1215,7 @@ export interface operations {
         message: string
         signature: string
       }
+      credentials: RequestCredentials
     }
     responses: {
       200: {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -45,6 +45,7 @@ import type {
 import type { RelayCountResponse, RelayTransactionRequest, RelayTransactionResponse } from './relay'
 import type { RegisterRecoveryModuleRequestBody } from './recovery'
 import type { Contract } from './contracts'
+import type { AuthNonce } from './auth'
 
 export type Primitive = string | number | boolean | null
 
@@ -449,6 +450,22 @@ export interface paths extends PathRegistry {
       path: {
         chainId: string
         contractAddress: string
+      }
+    }
+  }
+  '/v1/auth/nonce': {
+    get: operations['get_auth_nonce']
+    parameters: {
+      path: null
+    }
+  }
+  '/v1/auth/verify': {
+    post: operations['verify_auth']
+    parameters: {
+      path: null
+      body: {
+        message: string
+        signature: string
       }
     }
   }
@@ -1176,6 +1193,27 @@ export interface operations {
     responses: {
       200: {
         schema: Contract
+      }
+    }
+  }
+  get_auth_nonce: {
+    parameters: null
+    responses: {
+      200: {
+        schema: AuthNonce
+      }
+    }
+  }
+  verify_auth: {
+    parameters: {
+      body: {
+        message: string
+        signature: string
+      }
+    }
+    responses: {
+      200: {
+        schema: void
       }
     }
   }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,3 @@
+export type AuthNonce = {
+  nonce: string
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,7 +62,7 @@ export async function fetchData<T>(
   method: 'POST' | 'PUT' | 'DELETE',
   body?: unknown,
   headers?: Record<string, string>,
-  includeCredentials?: boolean,
+  credentials?: RequestCredentials,
 ): Promise<T> {
   const requestHeaders: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -74,8 +74,8 @@ export async function fetchData<T>(
     headers: requestHeaders,
   }
 
-  if (includeCredentials) {
-    options['credentials'] = 'include'
+  if (credentials) {
+    options['credentials'] = credentials
   }
 
   if (body != null) {
@@ -90,7 +90,7 @@ export async function fetchData<T>(
 export async function getData<T>(
   url: string,
   headers?: Record<string, string>,
-  includeCredentials?: boolean,
+  credentials?: RequestCredentials,
 ): Promise<T> {
   const options: RequestInit = {
     method: 'GET',
@@ -103,8 +103,8 @@ export async function getData<T>(
     }
   }
 
-  if (includeCredentials) {
-    options['credentials'] = 'include'
+  if (credentials) {
+    options['credentials'] = credentials
   }
 
   const resp = await fetch(url, options)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,6 +62,7 @@ export async function fetchData<T>(
   method: 'POST' | 'PUT' | 'DELETE',
   body?: unknown,
   headers?: Record<string, string>,
+  includeCredentials?: boolean,
 ): Promise<T> {
   const requestHeaders: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -73,6 +74,10 @@ export async function fetchData<T>(
     headers: requestHeaders,
   }
 
+  if (includeCredentials) {
+    options['credentials'] = 'include'
+  }
+
   if (body != null) {
     options.body = typeof body === 'string' ? body : JSON.stringify(body)
   }
@@ -82,7 +87,11 @@ export async function fetchData<T>(
   return parseResponse<T>(resp)
 }
 
-export async function getData<T>(url: string, headers?: Record<string, string>): Promise<T> {
+export async function getData<T>(
+  url: string,
+  headers?: Record<string, string>,
+  includeCredentials?: boolean,
+): Promise<T> {
   const options: RequestInit = {
     method: 'GET',
   }
@@ -92,6 +101,10 @@ export async function getData<T>(url: string, headers?: Record<string, string>):
       ...headers,
       'Content-Type': 'application/json',
     }
+  }
+
+  if (includeCredentials) {
+    options['credentials'] = 'include'
   }
 
   const resp = await fetch(url, options)

--- a/tests/endpoint.test.ts
+++ b/tests/endpoint.test.ts
@@ -18,7 +18,7 @@ describe('getEndpoint', () => {
       success: true,
     })
 
-    expect(getData).toHaveBeenCalledWith('https://test.test/v1/balances/supported-fiat-codes', undefined)
+    expect(getData).toHaveBeenCalledWith('https://test.test/v1/balances/supported-fiat-codes', undefined, undefined)
   })
 
   it('should accept a path param', async () => {
@@ -28,7 +28,7 @@ describe('getEndpoint', () => {
       }),
     ).resolves.toEqual({ success: true })
 
-    expect(getData).toHaveBeenCalledWith('https://test.test/v1/chains/4/safes/0x123', undefined)
+    expect(getData).toHaveBeenCalledWith('https://test.test/v1/chains/4/safes/0x123', undefined, undefined)
   })
 
   it('should accept several path params', async () => {
@@ -39,7 +39,7 @@ describe('getEndpoint', () => {
       }),
     ).resolves.toEqual({ success: true })
 
-    expect(getData).toHaveBeenCalledWith('https://test.test/v1/chains/4/safes/0x123/balances/usd', undefined)
+    expect(getData).toHaveBeenCalledWith('https://test.test/v1/chains/4/safes/0x123/balances/usd', undefined, undefined)
   })
 
   it('should accept query params', async () => {
@@ -52,6 +52,7 @@ describe('getEndpoint', () => {
 
     expect(getData).toHaveBeenCalledWith(
       'https://test.test/v1/chains/4/safes/0x123/balances/usd?exclude_spam=true',
+      undefined,
       undefined,
     )
   })
@@ -86,6 +87,7 @@ describe('getEndpoint', () => {
       'POST',
       body,
       undefined,
+      undefined,
     )
   })
 
@@ -99,7 +101,7 @@ describe('getEndpoint', () => {
       ),
     ).resolves.toEqual({ success: true })
 
-    expect(getData).toHaveBeenCalledWith('/test-url?raw=true')
+    expect(getData).toHaveBeenCalledWith('/test-url?raw=true', undefined, undefined)
   })
 
   it('should call a data decoder POST endpoint', async () => {
@@ -114,6 +116,7 @@ describe('getEndpoint', () => {
       'https://test.test/v1/chains/4/data-decoder',
       'POST',
       { data: '0x123' },
+      undefined,
       undefined,
     )
   })
@@ -130,6 +133,7 @@ describe('getEndpoint', () => {
       'https://test.test/v1/chains/4/safes/0x123/views/transaction-confirmation',
       'POST',
       { data: '0x456' },
+      undefined,
       undefined,
     )
   })
@@ -157,6 +161,7 @@ describe('getEndpoint', () => {
       'PUT',
       body,
       headers,
+      undefined,
     )
   })
 
@@ -176,6 +181,7 @@ describe('getEndpoint', () => {
       'https://test.test/v1/chains/4/transactions/0x456',
       'DELETE',
       body,
+      undefined,
       undefined,
     )
   })


### PR DESCRIPTION
## What it solves

- Adds two new functions `getAuthNonce` and `verifyAuth`
- Adds `includeCredentials` parameter to get/post/put/delete calls

## How to test

1. Checkout this branch locally and run `yarn link`
2. Use the local package in https://github.com/safe-global/safe-wallet-web/pull/3853
3. Observe the sign in flow still works