### PR TITLE
Add `ChainInfo['contractAddresses']` property

### DIFF
--- a/src/types/chains.ts
+++ b/src/types/chains.ts
@@ -95,6 +95,17 @@ export type ChainInfo = {
     chainName: string | null
     enabled: boolean
   }
+  contractAddresses: {
+    safeSingletonAddress: `0x${string}`
+    safeProxyFactoryAddress: `0x${string}`
+    multiSendAddress: `0x${string}`
+    multiSendCallOnlyAddress: `0x${string}`
+    fallbackHandlerAddress: `0x${string}`
+    signMessageLibAddress: `0x${string}`
+    createCallAddress: `0x${string}`
+    simulateTxAccessorAddress: `0x${string}`
+    safeWebAuthnSignerFactoryAddress: `0x${string}`
+  }
 }
 
 export type ChainListResponse = Page<ChainInfo>

--- a/src/types/chains.ts
+++ b/src/types/chains.ts
@@ -96,15 +96,15 @@ export type ChainInfo = {
     enabled: boolean
   }
   contractAddresses: {
-    safeSingletonAddress: `0x${string}`
-    safeProxyFactoryAddress: `0x${string}`
-    multiSendAddress: `0x${string}`
-    multiSendCallOnlyAddress: `0x${string}`
-    fallbackHandlerAddress: `0x${string}`
-    signMessageLibAddress: `0x${string}`
-    createCallAddress: `0x${string}`
-    simulateTxAccessorAddress: `0x${string}`
-    safeWebAuthnSignerFactoryAddress: `0x${string}`
+    safeSingletonAddress: `0x${string}` | null
+    safeProxyFactoryAddress: `0x${string}` | null
+    multiSendAddress: `0x${string}` | null
+    multiSendCallOnlyAddress: `0x${string}` | null
+    fallbackHandlerAddress: `0x${string}` | null
+    signMessageLibAddress: `0x${string}` | null
+    createCallAddress: `0x${string}` | null
+    simulateTxAccessorAddress: `0x${string}` | null
+    safeWebAuthnSignerFactoryAddress: `0x${string}` | null
   }
 }
 


### PR DESCRIPTION
## Summary

This adds the new `contractAddresses` object to the `ChainInfo` entity according to their inclusion in the [Safe Client Gateway](https://github.com/safe-global/safe-client-gateway/pull/1752) and [Safe Config. Service](https://github.com/safe-global/safe-config-service/pull/1175).

Reasoning: the Web currently relies on the `safe-deployments` package to initialise the SDK. This means, in order to run our infrastructure, addresses need be added to the aforementioned package. The values of `contractAddresses` map 1:1 with [the `ContractNetworksConfig`](https://docs.safe.global/sdk/protocol-kit/reference/safe#init)) of the `protocol-kit` making initialisation without presence in `safe-deployments` possible.

## Changes

- Add new (`0x${string} | null`) fields to `ChainInfo['contractAddresses']`:
  - `safeSingletonAddress`
  - `safeProxyFactoryAddress`
  - `multiSendAddress`
  - `multiSendCallOnlyAddress`
  - `fallbackHandlerAddress`
  - `signMessageLibAddress`
  - `createCallAddress`
  - `simulateTxAccessorAddress`
  - `safeWebAuthnSignerFactoryAddress`