### PR TITLE
Feat: add transaction_hash query param for module txs

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -588,6 +588,7 @@ export interface operations {
         module?: string
         to?: string
         timezone_offset?: number
+        transaction_hash?: string
       }
     }
     responses: {


### PR DESCRIPTION
Part of https://github.com/safe-global/safe-wallet-web/issues/3815

A new query param to get module txs by hash.

https://safe-client.safe.global/api#/transactions/TransactionsController_getModuleTransactions