### PR TITLE
Fix: ignore failed json parse

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,8 +17,8 @@ function replaceParam(str: string, key: string, value: string): string {
 export function insertParams(template: string, params?: Params): string {
   return params
     ? Object.keys(params).reduce((result: string, key) => {
-      return replaceParam(result, key, String(params[key]))
-    }, template)
+        return replaceParam(result, key, String(params[key]))
+      }, template)
     : template
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,8 +17,8 @@ function replaceParam(str: string, key: string, value: string): string {
 export function insertParams(template: string, params?: Params): string {
   return params
     ? Object.keys(params).reduce((result: string, key) => {
-        return replaceParam(result, key, String(params[key]))
-      }, template)
+      return replaceParam(result, key, String(params[key]))
+    }, template)
     : template
 }
 
@@ -41,16 +41,15 @@ async function parseResponse<T>(resp: Response): Promise<T> {
   let json
 
   try {
-    // An HTTP 204 - No Content response doesn't contain a body so trying to call .json() on it would throw
-    json = resp.status === 204 ? {} : await resp.json()
+    json = await resp.json()
   } catch {
-    if (resp.headers && resp.headers.get('content-length') !== '0') {
-      throw new Error(`Invalid response content: ${resp.statusText}`)
-    }
+    json = {}
   }
 
   if (!resp.ok) {
-    const errTxt = isErrorResponse(json) ? `${json.code}: ${json.message}` : resp.statusText
+    const errTxt = isErrorResponse(json)
+      ? `CGW error - ${json.code}: ${json.message}`
+      : `CGW error - status ${resp.statusText}`
     throw new Error(errTxt)
   }
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -198,18 +198,19 @@ describe('utils', () => {
       })
     })
 
-    it('should not throw for a 204 response', async () => {
-      const jsonMock = jest.fn()
+    it('should not throw for an non-JSON response', async () => {
+      const jsonMock = jest.fn().mockRejectedValue('error')
+
       fetchMock.mockImplementation(() => {
         return Promise.resolve({
           ok: true,
           status: 204,
+          statusText: 'No Content',
           json: jsonMock,
         })
       })
 
       await expect(fetchData('/test/safe', 'DELETE')).resolves.toEqual({})
-      expect(jsonMock).not.toHaveBeenCalled()
 
       expect(fetch).toHaveBeenCalledWith('/test/safe', {
         method: 'DELETE',


### PR DESCRIPTION
The delete transaction endpoint returns "OK" instead of a JSON. This seems to only happen in Cypress, so the behavior is not consistent across browsers (probably a bug in the CGW, @iamacook @hectorgomezv ?).

Anyway, this PR ignores non-JSON payloads and relies solely on the HTTP status code to return an error or success.