### PR TITLE
Feat: add CGW Accounts API specification

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -652,4 +652,47 @@ export function verifyAuth(body: operations['verify_auth']['parameters']['body']
   })
 }
 
+export function createAccount(body: operations['create_account']['parameters']['body']) {
+  return postEndpoint(baseUrl, '/v1/accounts', {
+    body,
+    credentials: 'include',
+  })
+}
+
+export function getAccount(address: string) {
+  return getEndpoint(baseUrl, '/v1/accounts/{address}', {
+    path: { address },
+    credentials: 'include',
+  })
+}
+
+export function deleteAccount(address: string) {
+  return deleteEndpoint(baseUrl, '/v1/accounts/{address}', {
+    path: { address },
+    credentials: 'include',
+  })
+}
+
+export function getAccountDataTypes() {
+  return getEndpoint(baseUrl, '/v1/accounts/data-types')
+}
+
+export function getAccountDataSettings(address: string) {
+  return getEndpoint(baseUrl, '/v1/accounts/{address}/data-settings', {
+    path: { address },
+    credentials: 'include',
+  })
+}
+
+export function putAccountDataSettings(
+  address: string,
+  body: operations['put_account_data_settings']['parameters']['body'],
+) {
+  return putEndpoint(baseUrl, '/v1/accounts/{address}/data-settings', {
+    path: { address },
+    body,
+    credentials: 'include',
+  })
+}
+
 /* eslint-enable @typescript-eslint/explicit-module-boundary-types */

--- a/src/types/accounts.ts
+++ b/src/types/accounts.ts
@@ -1,0 +1,29 @@
+export type Account = {
+  accountId: string
+  groupId: string | null
+  address: string
+}
+
+export type AccountDataType = {
+  id: string
+  name: string
+  description: string | null
+  isActive: boolean
+}
+
+export type AccountDataSetting = {
+  name: string
+  description: string | null
+  enabled: boolean
+}
+
+export type CreateAccountDto = {
+  address: string
+}
+
+export type UpsertAccountDataSettingsDto = {
+  accountDataSettings: {
+    id: string
+    enabled: boolean
+  }[]
+}

--- a/src/types/accounts.ts
+++ b/src/types/accounts.ts
@@ -1,7 +1,7 @@
 export type Account = {
   accountId: string
   groupId: string | null
-  address: string
+  address: `0x${string}`
 }
 
 export type AccountDataType = {
@@ -18,7 +18,7 @@ export type AccountDataSetting = {
 }
 
 export type CreateAccountDto = {
-  address: string
+  address: `0x${string}`
 }
 
 export type UpsertAccountDataSettingsDto = {

--- a/src/types/accounts.ts
+++ b/src/types/accounts.ts
@@ -1,5 +1,5 @@
 export type Account = {
-  accountId: string
+  id: string
   groupId: string | null
   address: `0x${string}`
 }
@@ -12,18 +12,14 @@ export type AccountDataType = {
 }
 
 export type AccountDataSetting = {
-  name: string
-  description: string | null
+  dataTypeId: string
   enabled: boolean
 }
 
-export type CreateAccountDto = {
+export type CreateAccountRequest = {
   address: `0x${string}`
 }
 
-export type UpsertAccountDataSettingsDto = {
-  accountDataSettings: {
-    id: string
-    enabled: boolean
-  }[]
+export type UpsertAccountDataSettingsRequest = {
+  accountDataSettings: AccountDataSetting[]
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -46,6 +46,13 @@ import type { RelayCountResponse, RelayTransactionRequest, RelayTransactionRespo
 import type { RegisterRecoveryModuleRequestBody } from './recovery'
 import type { Contract } from './contracts'
 import type { AuthNonce } from './auth'
+import {
+  Account,
+  AccountDataSetting,
+  AccountDataType,
+  CreateAccountDto,
+  UpsertAccountDataSettingsDto,
+} from './accounts'
 
 export type Primitive = string | number | boolean | null
 
@@ -470,6 +477,39 @@ export interface paths extends PathRegistry {
         message: string
         signature: string
       }
+    }
+  }
+  '/v1/accounts': {
+    post: operations['create_account']
+    parameters: {
+      path: null
+      credentials: 'include'
+    }
+  }
+  '/v1/accounts/{address}': {
+    get: operations['get_account']
+    delete: operations['delete_account']
+    parameters: {
+      path: {
+        address: string
+      }
+      credentials: 'include'
+    }
+  }
+  '/v1/accounts/data-types': {
+    get: operations['get_account_data_types']
+    parameters: {
+      path: null
+    }
+  }
+  '/v1/accounts/{address}/data-settings': {
+    get: operations['get_account_data_settings']
+    put: operations['put_account_data_settings']
+    parameters: {
+      path: {
+        address: string
+      }
+      credentials: 'include'
     }
   }
 }
@@ -1223,6 +1263,84 @@ export interface operations {
       200: {
         schema: void
       }
+    }
+  }
+  create_account: {
+    parameters: {
+      body: CreateAccountDto
+      credentials: 'include'
+    }
+    responses: {
+      200: {
+        schema: Account
+      }
+      403: unknown
+      422: unknown
+    }
+  }
+  get_account_data_types: {
+    parameters: null
+    responses: {
+      200: {
+        schema: AccountDataType[]
+      }
+    }
+  }
+  get_account_data_settings: {
+    parameters: {
+      path: {
+        address: string
+      }
+      credentials: 'include'
+    }
+    responses: {
+      200: {
+        schema: AccountDataSetting[]
+      }
+      403: unknown
+    }
+  }
+  put_account_data_settings: {
+    parameters: {
+      path: {
+        address: string
+      }
+      credentials: 'include'
+      body: UpsertAccountDataSettingsDto
+    }
+    responses: {
+      200: {
+        schema: AccountDataSetting[]
+      }
+      403: unknown
+    }
+  }
+  get_account: {
+    parameters: {
+      path: {
+        address: string
+      }
+      credentials: 'include'
+    }
+    responses: {
+      200: {
+        schema: Account
+      }
+      403: unknown
+    }
+  }
+  delete_account: {
+    parameters: {
+      path: {
+        address: string
+      }
+      credentials: 'include'
+    }
+    responses: {
+      204: {
+        schema: void
+      }
+      403: unknown
     }
   }
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -46,12 +46,12 @@ import type { RelayCountResponse, RelayTransactionRequest, RelayTransactionRespo
 import type { RegisterRecoveryModuleRequestBody } from './recovery'
 import type { Contract } from './contracts'
 import type { AuthNonce } from './auth'
-import {
+import type {
   Account,
   AccountDataSetting,
   AccountDataType,
-  CreateAccountDto,
-  UpsertAccountDataSettingsDto,
+  CreateAccountRequest,
+  UpsertAccountDataSettingsRequest,
 } from './accounts'
 
 export type Primitive = string | number | boolean | null

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1267,7 +1267,7 @@ export interface operations {
   }
   create_account: {
     parameters: {
-      body: CreateAccountDto
+      body: CreateAccountRequest
       credentials: 'include'
     }
     responses: {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1306,7 +1306,7 @@ export interface operations {
         address: string
       }
       credentials: 'include'
-      body: UpsertAccountDataSettingsDto
+      body: UpsertAccountDataSettingsRequest
     }
     responses: {
       200: {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1340,6 +1340,9 @@ export interface operations {
       204: {
         schema: void
       }
+      200: {
+        schema: void
+      }
       403: unknown
     }
   }


### PR DESCRIPTION
## Changes
- Adds user account type definitions: `Account`, `AccountDataType`, `AcocuntDataSetting`, `CreateAccountDto`, `UpsertAccountDataSettingsDto`.
- Adds requests/responses specifications for the following user account endpoints:
  - `POST /v1/accounts`
  - `GET /v1/accounts/{address}`
  - `DELETE /v1/accounts/{address}`
  - `GET /v1/accounts/data-types`
  - `GET /v1/accounts/{address}/data-settings`
  - `PUT /v1/accounts/{address}/data-settings`