### PR TITLE
fix: Change getDelegates to use v2 endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -418,7 +418,7 @@ export function confirmSafeMessage(
  * Returns a list of delegates
  */
 export function getDelegates(chainId: string, query: DelegatesRequest = {}): Promise<DelegateResponse> {
-  return getEndpoint(baseUrl, '/v1/chains/{chainId}/delegates', {
+  return getEndpoint(baseUrl, '/v2/chains/{chainId}/delegates', {
     path: { chainId },
     query,
   })

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -343,7 +343,7 @@ export interface paths extends PathRegistry {
       }
     }
   }
-  '/v1/chains/{chainId}/delegates': {
+  '/v2/chains/{chainId}/delegates': {
     get: operations['get_delegates']
     parameters: {
       path: {


### PR DESCRIPTION
## What it solves

Changes `getDelegates` to use the v2 endpoint since the v1 endpoint is deprecated. The v2 endpoint expects the same payload and returns the same result: https://github.com/safe-global/safe-client-gateway/pull/1501