### PR TITLE
Feat: transaction preview endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import type {
   SafeModuleTransactionsResponse,
   SafeMultisigTransactionsResponse,
   NoncesResponse,
+  TransactionPreview,
 } from './types/transactions'
 import type {
   EthereumAddress,
@@ -307,6 +308,22 @@ export function getConfirmationView(
   value?: operations['data_decoder']['parameters']['body']['value'],
 ): Promise<AnyConfirmationView> {
   return postEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{safe_address}/views/transaction-confirmation', {
+    path: { chainId, safe_address: safeAddress },
+    body: { data, to, value },
+  })
+}
+
+/**
+ * Get a tx preview
+ */
+export function getTxPreview(
+  chainId: string,
+  safeAddress: string,
+  data: operations['data_decoder']['parameters']['body']['data'],
+  to?: operations['data_decoder']['parameters']['body']['to'],
+  value?: operations['data_decoder']['parameters']['body']['value'],
+): Promise<TransactionPreview> {
+  return postEndpoint(baseUrl, '/v1/chains/{chainId}/transactions/{safe_address}/preview', {
     path: { chainId, safe_address: safeAddress },
     body: { data, to, value },
   })

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -16,6 +16,7 @@ import type {
   SafeModuleTransactionsResponse,
   SafeMultisigTransactionsResponse,
   NoncesResponse,
+  TransactionPreview,
 } from './transactions'
 import type { SafeInfo, SafeOverview } from './safe-info'
 import type { ChainListResponse, ChainInfo, ChainIndexingStatus } from './chains'
@@ -241,6 +242,15 @@ export interface paths extends PathRegistry {
   }
   '/v1/chains/{chainId}/transactions/{safe_address}/propose': {
     post: operations['propose_transaction']
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+      }
+    }
+  }
+  '/v1/chains/{chainId}/transactions/{safe_address}/preview': {
+    post: operations['preview_transaction']
     parameters: {
       path: {
         chainId: string
@@ -821,6 +831,24 @@ export interface operations {
     responses: {
       200: {
         schema: TransactionDetails
+      }
+      /** Safe not found */
+      404: unknown
+      /** Safe address checksum not valid */
+      422: unknown
+    }
+  }
+  preview_transaction: {
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+      }
+      body: DecodedDataRequest
+    }
+    responses: {
+      200: {
+        schema: TransactionPreview
       }
       /** Safe not found */
       404: unknown

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -529,6 +529,11 @@ export type TransactionDetails = {
 
 /* Transaction details types end */
 
+export type TransactionPreview = {
+  txInfo: TransactionInfo
+  txData: TransactionData
+}
+
 /* Transaction estimation types */
 
 export type SafeTransactionEstimationRequest = {


### PR DESCRIPTION
As per https://github.com/safe-global/safe-wallet-web/issues/4331, the `confirmation-view` endpoint is being deprecated in favor of `preview`.