### PR TITLE
fix(Swaps): add `executedFee` and `executedFeeToken`

### DIFF
--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -287,7 +287,11 @@ export type BaseOrder = {
   /** @description The URL to the explorer page of the order */
   explorerUrl: string
   /** @description The amount of fees paid for this order. */
-  executedSurplusFee?: string | null
+  executedSurplusFee: string | null
+  /** @description The amount of fees paid for this order */
+  executedFee: string | null
+  /** @description The token in which the fee was paid, expressed by SURPLUS tokens (BUY tokens for SELL orders and SELL tokens for BUY orders). */
+  executedFeeToken: OrderToken
   /** @description The (optional) address to receive the proceeds of the trade */
   receiver?: string | null
   owner: string

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -286,7 +286,10 @@ export type BaseOrder = {
   buyToken: OrderToken
   /** @description The URL to the explorer page of the order */
   explorerUrl: string
-  /** @description The amount of fees paid for this order. */
+  /** 
+   * @deprecated Use `executedFee` instead
+   * @description The amount of fees paid for this order.
+   */
   executedSurplusFee: string | null
   /** @description The amount of fees paid for this order */
   executedFee: string | null


### PR DESCRIPTION
## Summary

CoW will be deprecated `executedSurplusFee`, favouring `executedFee` and `executedFeeToken` in its place.

The propagates the [associated changes on the Client Gateway](https://github.com/safe-global/safe-client-gateway/pull/2247) to the SDK.

## Change

- Mark `executedSurplusFee` as deprecated
- Remove `undefined` as a potential `executedSurplusFee` type
- Add `executedFee` and `executedFeeToken`