### PR TITLE
Refactor: make TokeInfo type compatible with strings

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -14,13 +14,14 @@ export enum TokenType {
   ERC20 = 'ERC20',
   ERC721 = 'ERC721',
   NATIVE_TOKEN = 'NATIVE_TOKEN',
+  UNKNOWN = 'UNKNOWN',
 }
 
 /**
  * @see https://github.com/safe-global/safe-client-gateway/blob/main/src/common/models/backend/balances.rs
  */
 export type TokenInfo = {
-  type: TokenType
+  type: TokenType | 'ERC20' | 'ERC721' | 'NATIVE_TOKEN' | 'UNKNOWN'
   address: string
   decimals: number
   symbol: string


### PR DESCRIPTION
It makes it compatible with the new RTK SDK.